### PR TITLE
Feat: APIManager 구현

### DIFF
--- a/BookJam.xcodeproj/project.pbxproj
+++ b/BookJam.xcodeproj/project.pbxproj
@@ -10,6 +10,30 @@
 		88472A4D2B15D6D00073AE61 /* APIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88472A4C2B15D6D00073AE61 /* APIManager.swift */; };
 		88472A4F2B15D8100073AE61 /* APIEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88472A4E2B15D8100073AE61 /* APIEndpoint.swift */; };
 		88472A512B15D8500073AE61 /* BaseResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88472A502B15D8500073AE61 /* BaseResponse.swift */; };
+		88472A6A2B15D9210073AE61 /* PlaceIdReviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88472A522B15D9210073AE61 /* PlaceIdReviews.swift */; };
+		88472A6B2B15D9210073AE61 /* ReviewImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88472A532B15D9210073AE61 /* ReviewImage.swift */; };
+		88472A6C2B15D9210073AE61 /* LocationCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88472A542B15D9210073AE61 /* LocationCategory.swift */; };
+		88472A6D2B15D9210073AE61 /* PlaceIdActivities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88472A552B15D9210073AE61 /* PlaceIdActivities.swift */; };
+		88472A6E2B15D9210073AE61 /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88472A562B15D9210073AE61 /* Filter.swift */; };
+		88472A6F2B15D9210073AE61 /* KeywordSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88472A572B15D9210073AE61 /* KeywordSearch.swift */; };
+		88472A702B15D9210073AE61 /* Record.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88472A582B15D9210073AE61 /* Record.swift */; };
+		88472A712B15D9210073AE61 /* RecommendFriend.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88472A592B15D9210073AE61 /* RecommendFriend.swift */; };
+		88472A722B15D9210073AE61 /* SearchFriend.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88472A5A2B15D9210073AE61 /* SearchFriend.swift */; };
+		88472A732B15D9210073AE61 /* PlaceIdBooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88472A5B2B15D9210073AE61 /* PlaceIdBooks.swift */; };
+		88472A742B15D9220073AE61 /* UsersActivities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88472A5C2B15D9210073AE61 /* UsersActivities.swift */; };
+		88472A752B15D9220073AE61 /* RecordImages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88472A5D2B15D9210073AE61 /* RecordImages.swift */; };
+		88472A762B15D9220073AE61 /* PlaceId.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88472A5E2B15D9210073AE61 /* PlaceId.swift */; };
+		88472A772B15D9220073AE61 /* UsersOutline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88472A5F2B15D9210073AE61 /* UsersOutline.swift */; };
+		88472A782B15D9220073AE61 /* GetPlaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88472A602B15D9210073AE61 /* GetPlaces.swift */; };
+		88472A792B15D9220073AE61 /* Login.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88472A612B15D9210073AE61 /* Login.swift */; };
+		88472A7A2B15D9220073AE61 /* UsersRecords.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88472A622B15D9210073AE61 /* UsersRecords.swift */; };
+		88472A7B2B15D9220073AE61 /* BooksList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88472A632B15D9210073AE61 /* BooksList.swift */; };
+		88472A7C2B15D9220073AE61 /* UsersReviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88472A642B15D9210073AE61 /* UsersReviews.swift */; };
+		88472A7D2B15D9220073AE61 /* EmailDuplicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88472A652B15D9210073AE61 /* EmailDuplicate.swift */; };
+		88472A7E2B15D9220073AE61 /* SignUp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88472A662B15D9210073AE61 /* SignUp.swift */; };
+		88472A7F2B15D9220073AE61 /* RecordFriend.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88472A672B15D9210073AE61 /* RecordFriend.swift */; };
+		88472A802B15D9220073AE61 /* ReviewContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88472A682B15D9210073AE61 /* ReviewContent.swift */; };
+		88472A812B15D9220073AE61 /* PlaceIdNews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88472A692B15D9210073AE61 /* PlaceIdNews.swift */; };
 		949750F42AFDFAF000DCC096 /* MainDetailPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949750F32AFDFAF000DCC096 /* MainDetailPageViewController.swift */; };
 		949750F72AFE2FED00DCC096 /* BookActivityCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949750F62AFE2FED00DCC096 /* BookActivityCollectionViewCell.swift */; };
 		949750F92AFE303E00DCC096 /* BookListCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949750F82AFE303E00DCC096 /* BookListCollectionViewCell.swift */; };
@@ -52,6 +76,30 @@
 		88472A4C2B15D6D00073AE61 /* APIManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIManager.swift; sourceTree = "<group>"; };
 		88472A4E2B15D8100073AE61 /* APIEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIEndpoint.swift; sourceTree = "<group>"; };
 		88472A502B15D8500073AE61 /* BaseResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseResponse.swift; sourceTree = "<group>"; };
+		88472A522B15D9210073AE61 /* PlaceIdReviews.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaceIdReviews.swift; sourceTree = "<group>"; };
+		88472A532B15D9210073AE61 /* ReviewImage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReviewImage.swift; sourceTree = "<group>"; };
+		88472A542B15D9210073AE61 /* LocationCategory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationCategory.swift; sourceTree = "<group>"; };
+		88472A552B15D9210073AE61 /* PlaceIdActivities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaceIdActivities.swift; sourceTree = "<group>"; };
+		88472A562B15D9210073AE61 /* Filter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Filter.swift; sourceTree = "<group>"; };
+		88472A572B15D9210073AE61 /* KeywordSearch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeywordSearch.swift; sourceTree = "<group>"; };
+		88472A582B15D9210073AE61 /* Record.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Record.swift; sourceTree = "<group>"; };
+		88472A592B15D9210073AE61 /* RecommendFriend.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecommendFriend.swift; sourceTree = "<group>"; };
+		88472A5A2B15D9210073AE61 /* SearchFriend.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchFriend.swift; sourceTree = "<group>"; };
+		88472A5B2B15D9210073AE61 /* PlaceIdBooks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaceIdBooks.swift; sourceTree = "<group>"; };
+		88472A5C2B15D9210073AE61 /* UsersActivities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UsersActivities.swift; sourceTree = "<group>"; };
+		88472A5D2B15D9210073AE61 /* RecordImages.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecordImages.swift; sourceTree = "<group>"; };
+		88472A5E2B15D9210073AE61 /* PlaceId.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaceId.swift; sourceTree = "<group>"; };
+		88472A5F2B15D9210073AE61 /* UsersOutline.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UsersOutline.swift; sourceTree = "<group>"; };
+		88472A602B15D9210073AE61 /* GetPlaces.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GetPlaces.swift; sourceTree = "<group>"; };
+		88472A612B15D9210073AE61 /* Login.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Login.swift; sourceTree = "<group>"; };
+		88472A622B15D9210073AE61 /* UsersRecords.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UsersRecords.swift; sourceTree = "<group>"; };
+		88472A632B15D9210073AE61 /* BooksList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BooksList.swift; sourceTree = "<group>"; };
+		88472A642B15D9210073AE61 /* UsersReviews.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UsersReviews.swift; sourceTree = "<group>"; };
+		88472A652B15D9210073AE61 /* EmailDuplicate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmailDuplicate.swift; sourceTree = "<group>"; };
+		88472A662B15D9210073AE61 /* SignUp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignUp.swift; sourceTree = "<group>"; };
+		88472A672B15D9210073AE61 /* RecordFriend.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecordFriend.swift; sourceTree = "<group>"; };
+		88472A682B15D9210073AE61 /* ReviewContent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReviewContent.swift; sourceTree = "<group>"; };
+		88472A692B15D9210073AE61 /* PlaceIdNews.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaceIdNews.swift; sourceTree = "<group>"; };
 		949750F32AFDFAF000DCC096 /* MainDetailPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainDetailPageViewController.swift; sourceTree = "<group>"; };
 		949750F62AFE2FED00DCC096 /* BookActivityCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookActivityCollectionViewCell.swift; sourceTree = "<group>"; };
 		949750F82AFE303E00DCC096 /* BookListCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookListCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -117,6 +165,30 @@
 			isa = PBXGroup;
 			children = (
 				88472A502B15D8500073AE61 /* BaseResponse.swift */,
+				88472A632B15D9210073AE61 /* BooksList.swift */,
+				88472A652B15D9210073AE61 /* EmailDuplicate.swift */,
+				88472A562B15D9210073AE61 /* Filter.swift */,
+				88472A602B15D9210073AE61 /* GetPlaces.swift */,
+				88472A572B15D9210073AE61 /* KeywordSearch.swift */,
+				88472A542B15D9210073AE61 /* LocationCategory.swift */,
+				88472A612B15D9210073AE61 /* Login.swift */,
+				88472A5E2B15D9210073AE61 /* PlaceId.swift */,
+				88472A552B15D9210073AE61 /* PlaceIdActivities.swift */,
+				88472A5B2B15D9210073AE61 /* PlaceIdBooks.swift */,
+				88472A692B15D9210073AE61 /* PlaceIdNews.swift */,
+				88472A522B15D9210073AE61 /* PlaceIdReviews.swift */,
+				88472A592B15D9210073AE61 /* RecommendFriend.swift */,
+				88472A582B15D9210073AE61 /* Record.swift */,
+				88472A672B15D9210073AE61 /* RecordFriend.swift */,
+				88472A5D2B15D9210073AE61 /* RecordImages.swift */,
+				88472A682B15D9210073AE61 /* ReviewContent.swift */,
+				88472A532B15D9210073AE61 /* ReviewImage.swift */,
+				88472A5A2B15D9210073AE61 /* SearchFriend.swift */,
+				88472A662B15D9210073AE61 /* SignUp.swift */,
+				88472A5C2B15D9210073AE61 /* UsersActivities.swift */,
+				88472A5F2B15D9210073AE61 /* UsersOutline.swift */,
+				88472A622B15D9210073AE61 /* UsersRecords.swift */,
+				88472A642B15D9210073AE61 /* UsersReviews.swift */,
 			);
 			path = Entity;
 			sourceTree = "<group>";
@@ -359,35 +431,59 @@
 			buildActionMask = 2147483647;
 			files = (
 				949751032B020ACA00DCC096 /* BookStorePhotoCollectionViewCell.swift in Sources */,
+				88472A6F2B15D9210073AE61 /* KeywordSearch.swift in Sources */,
+				88472A7D2B15D9220073AE61 /* EmailDuplicate.swift in Sources */,
+				88472A782B15D9220073AE61 /* GetPlaces.swift in Sources */,
+				88472A6B2B15D9210073AE61 /* ReviewImage.swift in Sources */,
 				DD0919252AFA6B4F001E5501 /* UIViewController+.swift in Sources */,
+				88472A752B15D9220073AE61 /* RecordImages.swift in Sources */,
+				88472A742B15D9220073AE61 /* UsersActivities.swift in Sources */,
 				949751092B022EBA00DCC096 /* GetPlaces.swift in Sources */,
 				DD0919262AFA6B4F001E5501 /* UIScrollView+.swift in Sources */,
 				949750F42AFDFAF000DCC096 /* MainDetailPageViewController.swift in Sources */,
 				DD0919242AFA6B4F001E5501 /* UIView+.swift in Sources */,
+				88472A6A2B15D9210073AE61 /* PlaceIdReviews.swift in Sources */,
 				DD754DED2AFA4D920001FBC4 /* ViewController.swift in Sources */,
 				949750FF2AFE398200DCC096 /* BookReviewCollectionViewCell.swift in Sources */,
 				88472A4D2B15D6D00073AE61 /* APIManager.swift in Sources */,
 				94A844FD2B04D1280036DE72 /* PlaceNetwork.swift in Sources */,
+				88472A7A2B15D9220073AE61 /* UsersRecords.swift in Sources */,
+				88472A772B15D9220073AE61 /* UsersOutline.swift in Sources */,
+				88472A792B15D9220073AE61 /* Login.swift in Sources */,
 				DD754DE92AFA4D920001FBC4 /* AppDelegate.swift in Sources */,
 				DD0919182AFA6225001E5501 /* ColorData.swift in Sources */,
+				88472A722B15D9210073AE61 /* SearchFriend.swift in Sources */,
 				94A844FB2B04C6C80036DE72 /* Network.swift in Sources */,
+				88472A6C2B15D9210073AE61 /* LocationCategory.swift in Sources */,
 				94A844FF2B0601980036DE72 /* MainDetailSegmentedControl.swift in Sources */,
 				DD0919272AFA6B4F001E5501 /* UIImage+.swift in Sources */,
 				88472A512B15D8500073AE61 /* BaseResponse.swift in Sources */,
 				949750F92AFE303E00DCC096 /* BookListCollectionViewCell.swift in Sources */,
 				DD0919162AFA621D001E5501 /* FontData.swift in Sources */,
+				88472A712B15D9210073AE61 /* RecommendFriend.swift in Sources */,
+				88472A6E2B15D9210073AE61 /* Filter.swift in Sources */,
+				88472A702B15D9210073AE61 /* Record.swift in Sources */,
+				88472A6D2B15D9210073AE61 /* PlaceIdActivities.swift in Sources */,
 				DD754DEB2AFA4D920001FBC4 /* SceneDelegate.swift in Sources */,
 				9497510D2B022EED00DCC096 /* Books.swift in Sources */,
 				88472A4F2B15D8100073AE61 /* APIEndpoint.swift in Sources */,
+				88472A7B2B15D9220073AE61 /* BooksList.swift in Sources */,
 				9497510F2B022EF900DCC096 /* Activities.swift in Sources */,
+				88472A7E2B15D9220073AE61 /* SignUp.swift in Sources */,
 				949750F72AFE2FED00DCC096 /* BookActivityCollectionViewCell.swift in Sources */,
+				88472A7C2B15D9220073AE61 /* UsersReviews.swift in Sources */,
 				94A844F82B04C6570036DE72 /* MainDetailPageViewModel.swift in Sources */,
 				949751072B022E1B00DCC096 /* Review.swift in Sources */,
+				88472A762B15D9220073AE61 /* PlaceId.swift in Sources */,
 				949750FD2AFE370900DCC096 /* BookNewsCollectionViewCell.swift in Sources */,
 				949751012AFE3C1300DCC096 /* MainDetailTopView.swift in Sources */,
 				9497510B2B022EE000DCC096 /* News.swift in Sources */,
+				88472A7F2B15D9220073AE61 /* RecordFriend.swift in Sources */,
+				88472A732B15D9210073AE61 /* PlaceIdBooks.swift in Sources */,
 				DD0919282AFA6B4F001E5501 /* UIColor+.swift in Sources */,
+				88472A812B15D9220073AE61 /* PlaceIdNews.swift in Sources */,
 				949750FB2AFE347100DCC096 /* HeaderView.swift in Sources */,
+				88472A802B15D9220073AE61 /* ReviewContent.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BookJam.xcodeproj/project.pbxproj
+++ b/BookJam.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		88472A4D2B15D6D00073AE61 /* APIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88472A4C2B15D6D00073AE61 /* APIManager.swift */; };
+		88472A4F2B15D8100073AE61 /* APIEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88472A4E2B15D8100073AE61 /* APIEndpoint.swift */; };
+		88472A512B15D8500073AE61 /* BaseResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88472A502B15D8500073AE61 /* BaseResponse.swift */; };
 		949750F42AFDFAF000DCC096 /* MainDetailPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949750F32AFDFAF000DCC096 /* MainDetailPageViewController.swift */; };
 		949750F72AFE2FED00DCC096 /* BookActivityCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949750F62AFE2FED00DCC096 /* BookActivityCollectionViewCell.swift */; };
 		949750F92AFE303E00DCC096 /* BookListCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949750F82AFE303E00DCC096 /* BookListCollectionViewCell.swift */; };
@@ -46,6 +49,9 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		88472A4C2B15D6D00073AE61 /* APIManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIManager.swift; sourceTree = "<group>"; };
+		88472A4E2B15D8100073AE61 /* APIEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIEndpoint.swift; sourceTree = "<group>"; };
+		88472A502B15D8500073AE61 /* BaseResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseResponse.swift; sourceTree = "<group>"; };
 		949750F32AFDFAF000DCC096 /* MainDetailPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainDetailPageViewController.swift; sourceTree = "<group>"; };
 		949750F62AFE2FED00DCC096 /* BookActivityCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookActivityCollectionViewCell.swift; sourceTree = "<group>"; };
 		949750F82AFE303E00DCC096 /* BookListCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookListCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -97,6 +103,24 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		88472A492B15D5750073AE61 /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				88472A4A2B15D57D0073AE61 /* Entity */,
+				88472A4C2B15D6D00073AE61 /* APIManager.swift */,
+				88472A4E2B15D8100073AE61 /* APIEndpoint.swift */,
+			);
+			path = Network;
+			sourceTree = "<group>";
+		};
+		88472A4A2B15D57D0073AE61 /* Entity */ = {
+			isa = PBXGroup;
+			children = (
+				88472A502B15D8500073AE61 /* BaseResponse.swift */,
+			);
+			path = Entity;
+			sourceTree = "<group>";
+		};
 		949750F02AFDF99A00DCC096 /* DetailPage */ = {
 			isa = PBXGroup;
 			children = (
@@ -239,6 +263,7 @@
 		DD754DE72AFA4D920001FBC4 /* BookJam */ = {
 			isa = PBXGroup;
 			children = (
+				88472A492B15D5750073AE61 /* Network */,
 				DD754DE82AFA4D920001FBC4 /* AppDelegate.swift */,
 				DD754DEA2AFA4D920001FBC4 /* SceneDelegate.swift */,
 				DD0919132AFA5FCA001E5501 /* Resource */,
@@ -341,16 +366,19 @@
 				DD0919242AFA6B4F001E5501 /* UIView+.swift in Sources */,
 				DD754DED2AFA4D920001FBC4 /* ViewController.swift in Sources */,
 				949750FF2AFE398200DCC096 /* BookReviewCollectionViewCell.swift in Sources */,
+				88472A4D2B15D6D00073AE61 /* APIManager.swift in Sources */,
 				94A844FD2B04D1280036DE72 /* PlaceNetwork.swift in Sources */,
 				DD754DE92AFA4D920001FBC4 /* AppDelegate.swift in Sources */,
 				DD0919182AFA6225001E5501 /* ColorData.swift in Sources */,
 				94A844FB2B04C6C80036DE72 /* Network.swift in Sources */,
 				94A844FF2B0601980036DE72 /* MainDetailSegmentedControl.swift in Sources */,
 				DD0919272AFA6B4F001E5501 /* UIImage+.swift in Sources */,
+				88472A512B15D8500073AE61 /* BaseResponse.swift in Sources */,
 				949750F92AFE303E00DCC096 /* BookListCollectionViewCell.swift in Sources */,
 				DD0919162AFA621D001E5501 /* FontData.swift in Sources */,
 				DD754DEB2AFA4D920001FBC4 /* SceneDelegate.swift in Sources */,
 				9497510D2B022EED00DCC096 /* Books.swift in Sources */,
+				88472A4F2B15D8100073AE61 /* APIEndpoint.swift in Sources */,
 				9497510F2B022EF900DCC096 /* Activities.swift in Sources */,
 				949750F72AFE2FED00DCC096 /* BookActivityCollectionViewCell.swift in Sources */,
 				94A844F82B04C6570036DE72 /* MainDetailPageViewModel.swift in Sources */,

--- a/BookJam.xcodeproj/project.pbxproj
+++ b/BookJam.xcodeproj/project.pbxproj
@@ -42,11 +42,6 @@
 		949750FF2AFE398200DCC096 /* BookReviewCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949750FE2AFE398200DCC096 /* BookReviewCollectionViewCell.swift */; };
 		949751012AFE3C1300DCC096 /* MainDetailTopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949751002AFE3C1300DCC096 /* MainDetailTopView.swift */; };
 		949751032B020ACA00DCC096 /* BookStorePhotoCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949751022B020ACA00DCC096 /* BookStorePhotoCollectionViewCell.swift */; };
-		949751072B022E1B00DCC096 /* Review.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949751062B022E1B00DCC096 /* Review.swift */; };
-		949751092B022EBA00DCC096 /* GetPlaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949751082B022EBA00DCC096 /* GetPlaces.swift */; };
-		9497510B2B022EE000DCC096 /* News.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9497510A2B022EE000DCC096 /* News.swift */; };
-		9497510D2B022EED00DCC096 /* Books.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9497510C2B022EED00DCC096 /* Books.swift */; };
-		9497510F2B022EF900DCC096 /* Activities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9497510E2B022EF900DCC096 /* Activities.swift */; };
 		94A844F82B04C6570036DE72 /* MainDetailPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94A844F72B04C6570036DE72 /* MainDetailPageViewModel.swift */; };
 		94A844FB2B04C6C80036DE72 /* Network.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94A844FA2B04C6C80036DE72 /* Network.swift */; };
 		94A844FD2B04D1280036DE72 /* PlaceNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94A844FC2B04D1280036DE72 /* PlaceNetwork.swift */; };
@@ -108,11 +103,6 @@
 		949750FE2AFE398200DCC096 /* BookReviewCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookReviewCollectionViewCell.swift; sourceTree = "<group>"; };
 		949751002AFE3C1300DCC096 /* MainDetailTopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainDetailTopView.swift; sourceTree = "<group>"; };
 		949751022B020ACA00DCC096 /* BookStorePhotoCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookStorePhotoCollectionViewCell.swift; sourceTree = "<group>"; };
-		949751062B022E1B00DCC096 /* Review.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Review.swift; sourceTree = "<group>"; };
-		949751082B022EBA00DCC096 /* GetPlaces.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetPlaces.swift; sourceTree = "<group>"; };
-		9497510A2B022EE000DCC096 /* News.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = News.swift; sourceTree = "<group>"; };
-		9497510C2B022EED00DCC096 /* Books.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Books.swift; sourceTree = "<group>"; };
-		9497510E2B022EF900DCC096 /* Activities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Activities.swift; sourceTree = "<group>"; };
 		94A844F72B04C6570036DE72 /* MainDetailPageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainDetailPageViewModel.swift; sourceTree = "<group>"; };
 		94A844FA2B04C6C80036DE72 /* Network.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Network.swift; sourceTree = "<group>"; };
 		94A844FC2B04D1280036DE72 /* PlaceNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceNetwork.swift; sourceTree = "<group>"; };
@@ -239,21 +229,8 @@
 			isa = PBXGroup;
 			children = (
 				94A844F92B04C6A20036DE72 /* Network */,
-				949751052B022E0700DCC096 /* Entity */,
 			);
 			path = Model;
-			sourceTree = "<group>";
-		};
-		949751052B022E0700DCC096 /* Entity */ = {
-			isa = PBXGroup;
-			children = (
-				949751082B022EBA00DCC096 /* GetPlaces.swift */,
-				949751062B022E1B00DCC096 /* Review.swift */,
-				9497510A2B022EE000DCC096 /* News.swift */,
-				9497510C2B022EED00DCC096 /* Books.swift */,
-				9497510E2B022EF900DCC096 /* Activities.swift */,
-			);
-			path = Entity;
 			sourceTree = "<group>";
 		};
 		94A844F92B04C6A20036DE72 /* Network */ = {
@@ -438,7 +415,6 @@
 				DD0919252AFA6B4F001E5501 /* UIViewController+.swift in Sources */,
 				88472A752B15D9220073AE61 /* RecordImages.swift in Sources */,
 				88472A742B15D9220073AE61 /* UsersActivities.swift in Sources */,
-				949751092B022EBA00DCC096 /* GetPlaces.swift in Sources */,
 				DD0919262AFA6B4F001E5501 /* UIScrollView+.swift in Sources */,
 				949750F42AFDFAF000DCC096 /* MainDetailPageViewController.swift in Sources */,
 				DD0919242AFA6B4F001E5501 /* UIView+.swift in Sources */,
@@ -465,19 +441,15 @@
 				88472A702B15D9210073AE61 /* Record.swift in Sources */,
 				88472A6D2B15D9210073AE61 /* PlaceIdActivities.swift in Sources */,
 				DD754DEB2AFA4D920001FBC4 /* SceneDelegate.swift in Sources */,
-				9497510D2B022EED00DCC096 /* Books.swift in Sources */,
 				88472A4F2B15D8100073AE61 /* APIEndpoint.swift in Sources */,
 				88472A7B2B15D9220073AE61 /* BooksList.swift in Sources */,
-				9497510F2B022EF900DCC096 /* Activities.swift in Sources */,
 				88472A7E2B15D9220073AE61 /* SignUp.swift in Sources */,
 				949750F72AFE2FED00DCC096 /* BookActivityCollectionViewCell.swift in Sources */,
 				88472A7C2B15D9220073AE61 /* UsersReviews.swift in Sources */,
 				94A844F82B04C6570036DE72 /* MainDetailPageViewModel.swift in Sources */,
-				949751072B022E1B00DCC096 /* Review.swift in Sources */,
 				88472A762B15D9220073AE61 /* PlaceId.swift in Sources */,
 				949750FD2AFE370900DCC096 /* BookNewsCollectionViewCell.swift in Sources */,
 				949751012AFE3C1300DCC096 /* MainDetailTopView.swift in Sources */,
-				9497510B2B022EE000DCC096 /* News.swift in Sources */,
 				88472A7F2B15D9220073AE61 /* RecordFriend.swift in Sources */,
 				88472A732B15D9210073AE61 /* PlaceIdBooks.swift in Sources */,
 				DD0919282AFA6B4F001E5501 /* UIColor+.swift in Sources */,

--- a/BookJam.xcodeproj/project.pbxproj
+++ b/BookJam.xcodeproj/project.pbxproj
@@ -34,6 +34,8 @@
 		88472A7F2B15D9220073AE61 /* RecordFriend.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88472A672B15D9210073AE61 /* RecordFriend.swift */; };
 		88472A802B15D9220073AE61 /* ReviewContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88472A682B15D9210073AE61 /* ReviewContent.swift */; };
 		88472A812B15D9220073AE61 /* PlaceIdNews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88472A692B15D9210073AE61 /* PlaceIdNews.swift */; };
+		88472A832B15EFDE0073AE61 /* APIHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88472A822B15EFDE0073AE61 /* APIHeader.swift */; };
+		88472A852B15F0050073AE61 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88472A842B15F0050073AE61 /* NetworkError.swift */; };
 		949750F42AFDFAF000DCC096 /* MainDetailPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949750F32AFDFAF000DCC096 /* MainDetailPageViewController.swift */; };
 		949750F72AFE2FED00DCC096 /* BookActivityCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949750F62AFE2FED00DCC096 /* BookActivityCollectionViewCell.swift */; };
 		949750F92AFE303E00DCC096 /* BookListCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949750F82AFE303E00DCC096 /* BookListCollectionViewCell.swift */; };
@@ -95,6 +97,8 @@
 		88472A672B15D9210073AE61 /* RecordFriend.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecordFriend.swift; sourceTree = "<group>"; };
 		88472A682B15D9210073AE61 /* ReviewContent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReviewContent.swift; sourceTree = "<group>"; };
 		88472A692B15D9210073AE61 /* PlaceIdNews.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaceIdNews.swift; sourceTree = "<group>"; };
+		88472A822B15EFDE0073AE61 /* APIHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIHeader.swift; sourceTree = "<group>"; };
+		88472A842B15F0050073AE61 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		949750F32AFDFAF000DCC096 /* MainDetailPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainDetailPageViewController.swift; sourceTree = "<group>"; };
 		949750F62AFE2FED00DCC096 /* BookActivityCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookActivityCollectionViewCell.swift; sourceTree = "<group>"; };
 		949750F82AFE303E00DCC096 /* BookListCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookListCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -147,6 +151,8 @@
 				88472A4A2B15D57D0073AE61 /* Entity */,
 				88472A4C2B15D6D00073AE61 /* APIManager.swift */,
 				88472A4E2B15D8100073AE61 /* APIEndpoint.swift */,
+				88472A822B15EFDE0073AE61 /* APIHeader.swift */,
+				88472A842B15F0050073AE61 /* NetworkError.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -407,11 +413,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				88472A852B15F0050073AE61 /* NetworkError.swift in Sources */,
 				949751032B020ACA00DCC096 /* BookStorePhotoCollectionViewCell.swift in Sources */,
 				88472A6F2B15D9210073AE61 /* KeywordSearch.swift in Sources */,
 				88472A7D2B15D9220073AE61 /* EmailDuplicate.swift in Sources */,
 				88472A782B15D9220073AE61 /* GetPlaces.swift in Sources */,
 				88472A6B2B15D9210073AE61 /* ReviewImage.swift in Sources */,
+				88472A832B15EFDE0073AE61 /* APIHeader.swift in Sources */,
 				DD0919252AFA6B4F001E5501 /* UIViewController+.swift in Sources */,
 				88472A752B15D9220073AE61 /* RecordImages.swift in Sources */,
 				88472A742B15D9220073AE61 /* UsersActivities.swift in Sources */,

--- a/BookJam/Network/APIEndpoint.swift
+++ b/BookJam/Network/APIEndpoint.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Alamofire
 
 enum NetworkError: Error {
     case invalidURL
@@ -18,6 +19,39 @@ enum NetworkError: Error {
 //enum HTTPMethod: String {
 //
 //}
+
+enum APIHeader {
+    // 얘네 테스트용이니 다 날려야 함
+    static let jwtToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjMzLCJpYXQiOjE2OTIwMDExNDQsImV4cCI6MTc5MjAwNDc0NCwiaXNzIjoiYm9va2phbSJ9.BGN1CGC4Zu8xRVuH_zA-aTK1GYMWvNitR2mAfgG1zWU"
+
+    static let kakaoAppID = "e71c9521872b70f64acf3a7139889342"
+    
+    case header
+    case sendImageHeader
+    
+    var getValue: HTTPHeaders {
+        switch self {
+        case .header :
+            return [    //임시 슈퍼 jwt 토큰
+                "Authorization": "Bearer \(APIHeader.jwtToken)"
+            ]
+        case .sendImageHeader :
+            return [
+                "Authorization": "Bearer \(APIHeader.jwtToken)",
+                "Content-Type" : "multipart/form-data"
+            ]
+        }
+    }
+
+    // 추후 Token 로직 구현되었을 때 예시 with KeyChain
+//    case .logout:
+//        return ["Authorization": KeyChain.shared.read(account: .accessToken),
+//                "Refresh-Token": KeyChain.shared.read(account: .refreshToken),
+//                "Content-Type": "application/json"]
+//    default:
+//        return ["Authorization": KeyChain.shared.read(account: .accessToken),
+//                "Content-Type": "application/json"]
+}
 
 
 enum APIEndPoint {

--- a/BookJam/Network/APIEndpoint.swift
+++ b/BookJam/Network/APIEndpoint.swift
@@ -1,0 +1,110 @@
+//
+//  Endpoint.swift
+//  BookJam
+//
+//  Created by 박민서 on 11/23/23.
+//
+
+import Foundation
+
+enum NetworkError: Error {
+    case invalidURL
+    case invalidDataEncoding
+    case requestFailed(Error)
+    case invalidResponse
+    case responseDataDecodingFailed(Error)
+}
+
+//enum HTTPMethod: String {
+//
+//}
+
+
+enum APIEndPoint {
+    static let baseURL = "https://bookjam.shop"
+    // Auth
+    case postAuthEmailCheck
+    case getAuthFriends
+    case postAuthLogin
+    
+    // User
+    case getSearchUser
+    case getUsersOutline
+    case getUsersActivities
+    case getUsersReviews
+    case getUsersRecords(category: Int)
+    
+    // Place
+    case getPlaces
+    case getPlacesSearch
+    case getPlaceId(placeId: Int)
+    case getPlaceNewsURL(placeId: Int)
+    case getPlaceBooksURL(placeId: Int)
+    case getPlaceActivitiesURL(placeId: Int)
+    case getPlaceReviewsURL(placeId: Int)
+    case postPlacesReviews(placeId: Int)
+    case postReviewsImages(reviewId: Int)
+    
+    // Book
+    case getBooksList(title: String)
+    
+    // Record
+    case postRecord
+    case getRecordsFriends
+    case postRecordsImages(recordId: Int)
+    
+    // 사용 시 접근 예시 : APIEndPoint.getAuthFriends.url
+    var url: String {
+        switch self {
+        // Auth
+        case .postAuthEmailCheck:
+            return "/auth/email-check"
+        case .getAuthFriends:
+            return "/auth/friends"
+        case .postAuthLogin:
+            return "/auth/login"
+        // User
+        case .getSearchUser:
+            return "/user/search"
+        case .getUsersOutline:
+            return "/users/outline"
+        case .getUsersActivities:
+            return "/users/activities"
+        case .getUsersReviews:
+            return "/users/reviews"
+        case .getUsersRecords(let category):
+            return "/users/records?category=\(category)"
+        // Place
+        case .getPlaces:
+            return "/places"
+        case .getPlacesSearch:
+            return "/places/search"
+        case .getPlaceId(let placeId):
+            return "/places/\(placeId)"
+        case .getPlaceNewsURL(let placeId):
+            return "/places/\(placeId)/news"
+        case .getPlaceBooksURL(let placeId):
+            return "/places/\(placeId)/books"
+        case .getPlaceActivitiesURL(let placeId):
+            return "/places/\(placeId)/activities"
+        case .getPlaceReviewsURL(let placeId):
+            return "/places/\(placeId)/reviews"
+        case .postPlacesReviews(let placeId):
+            return "/places/\(placeId)/reviews"
+        case .postReviewsImages(let reviewId):
+            return "/reviews/\(reviewId)/images"
+        // Book
+        case .getBooksList(let title):
+            return "/books/list?title=\(title)"
+            
+        // Record
+        case .postRecord:
+            return "/records"
+        case .getRecordsFriends:
+            return "/records/friends"
+        case .postRecordsImages(let recordId):
+            return "/records/\(recordId)/images"
+        }
+        
+    }
+}

--- a/BookJam/Network/APIEndpoint.swift
+++ b/BookJam/Network/APIEndpoint.swift
@@ -1,58 +1,11 @@
 //
-//  Endpoint.swift
+//  APIEndpoint.swift
 //  BookJam
 //
 //  Created by 박민서 on 11/23/23.
 //
 
 import Foundation
-import Alamofire
-
-enum NetworkError: Error {
-    case invalidURL
-    case invalidDataEncoding
-    case requestFailed(Error)
-    case invalidResponse
-    case responseDataDecodingFailed(Error)
-}
-
-//enum HTTPMethod: String {
-//
-//}
-
-enum APIHeader {
-    // 얘네 테스트용이니 다 날려야 함
-    static let jwtToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjMzLCJpYXQiOjE2OTIwMDExNDQsImV4cCI6MTc5MjAwNDc0NCwiaXNzIjoiYm9va2phbSJ9.BGN1CGC4Zu8xRVuH_zA-aTK1GYMWvNitR2mAfgG1zWU"
-
-    static let kakaoAppID = "e71c9521872b70f64acf3a7139889342"
-    
-    case header
-    case sendImageHeader
-    
-    var getValue: HTTPHeaders {
-        switch self {
-        case .header :
-            return [    //임시 슈퍼 jwt 토큰
-                "Authorization": "Bearer \(APIHeader.jwtToken)"
-            ]
-        case .sendImageHeader :
-            return [
-                "Authorization": "Bearer \(APIHeader.jwtToken)",
-                "Content-Type" : "multipart/form-data"
-            ]
-        }
-    }
-
-    // 추후 Token 로직 구현되었을 때 예시 with KeyChain
-//    case .logout:
-//        return ["Authorization": KeyChain.shared.read(account: .accessToken),
-//                "Refresh-Token": KeyChain.shared.read(account: .refreshToken),
-//                "Content-Type": "application/json"]
-//    default:
-//        return ["Authorization": KeyChain.shared.read(account: .accessToken),
-//                "Content-Type": "application/json"]
-}
-
 
 enum APIEndPoint {
     static let baseURL = "https://bookjam.shop"

--- a/BookJam/Network/APIHeader.swift
+++ b/BookJam/Network/APIHeader.swift
@@ -1,0 +1,42 @@
+//
+//  APIHeader.swift
+//  BookJam
+//
+//  Created by 박민서 on 11/28/23.
+//
+
+import Foundation
+import Alamofire
+
+enum APIHeader {
+    // 얘네 테스트용이니 다 날려야 함
+    static let jwtToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjMzLCJpYXQiOjE2OTIwMDExNDQsImV4cCI6MTc5MjAwNDc0NCwiaXNzIjoiYm9va2phbSJ9.BGN1CGC4Zu8xRVuH_zA-aTK1GYMWvNitR2mAfgG1zWU"
+
+    static let kakaoAppID = "e71c9521872b70f64acf3a7139889342"
+    
+    case header
+    case sendImageHeader
+    
+    var getValue: HTTPHeaders {
+        switch self {
+        case .header :
+            return [    //임시 슈퍼 jwt 토큰
+                "Authorization": "Bearer \(APIHeader.jwtToken)"
+            ]
+        case .sendImageHeader :
+            return [
+                "Authorization": "Bearer \(APIHeader.jwtToken)",
+                "Content-Type" : "multipart/form-data"
+            ]
+        }
+    }
+
+    // 추후 Token 로직 구현되었을 때 예시 with KeyChain
+//    case .logout:
+//        return ["Authorization": KeyChain.shared.read(account: .accessToken),
+//                "Refresh-Token": KeyChain.shared.read(account: .refreshToken),
+//                "Content-Type": "application/json"]
+//    default:
+//        return ["Authorization": KeyChain.shared.read(account: .accessToken),
+//                "Content-Type": "application/json"]
+}

--- a/BookJam/Network/APIManager.swift
+++ b/BookJam/Network/APIManager.swift
@@ -13,26 +13,11 @@ import RxSwift
 
 class APIManager: ObservableObject  {
     static let shared = APIManager()
-    private lazy var headers: HTTPHeaders = [    //임시 슈퍼 jwt 토큰
-        "Authorization": "Bearer \(jwtToken)"
-    ]
-    
-    func setHeaderToSendImage() -> HTTPHeaders {
-        headers = [
-            "Authorization": "Bearer \(jwtToken)",
-            "Content-Type" : "multipart/form-data"
-        ]
-        return headers
-    }
-    
-    // 얘네 테스트용이니 다 날려야 함
-    let jwtToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjMzLCJpYXQiOjE2OTIwMDExNDQsImV4cCI6MTc5MjAwNDc0NCwiaXNzIjoiYm9va2phbSJ9.BGN1CGC4Zu8xRVuH_zA-aTK1GYMWvNitR2mAfgG1zWU"
-
-    let kakaoAppID = "e71c9521872b70f64acf3a7139889342"
 }
 
 // MARK: T에는 요청값 데이터의 모델, U에는 응닶값 데이터의 모델 적기
 extension APIManager {
+    
     func getData<T: Encodable, U: Decodable>(urlEndpointString: APIEndPoint,
                                            responseDataType: U.Type,
                                            requestDataType: T.Type,
@@ -42,13 +27,14 @@ extension APIManager {
         guard let url = URL(string: APIEndPoint.baseURL + urlEndpointString.url) else {
             return Observable.error(NetworkError.invalidURL)
         }
+        
         print("get 요청 URL --> \(url)")
         print("Request 쿼리 --> \(String(describing: parameter))")
         
         
         return Observable.create { emitter in
             AF
-                .request(url, method: .get, parameters: parameter, headers: self.headers)
+                .request(url, method: .get, parameters: parameter, headers: APIHeader.header.getValue)
 //                .validate(statusCode: 200..<300) // validation code를 몰라요
                 .responseDecodable(of: BaseResponse<U>.self) { response in
                     print(response)
@@ -72,24 +58,35 @@ extension APIManager {
     func postData<T: Codable, U: Decodable>(urlEndpointString: APIEndPoint,
                                             responseDataType: U.Type,
                                             requestDataType: T.Type,
-                                            parameter: T?,
-                                            completionHandler: @escaping (U)->Void) {
-        guard let url = URL(string: APIEndPoint.baseURL + urlEndpointString.url) else { return }
+                                            parameter: T?
+    ) -> Observable<U>{
+        
+        guard let url = URL(string: APIEndPoint.baseURL + urlEndpointString.url) else {
+            return Observable.error(NetworkError.invalidURL)
+        }
+        
         print("post 요청 URL --> \(url)")
-        print("Request 쿼리 --> \(parameter)")
-
-        AF
-            .request(url, method: .post, parameters: parameter, encoder: .json, headers: self.headers)
-            .responseDecodable(of: U.self) { response in
-                //print(response)
-                switch response.result {
-                case .success(let success):
-                    completionHandler(success)
-                case .failure(let error):
-                    print(error.localizedDescription)
+        print("Request 쿼리 --> \(String(describing: parameter))")
+        
+        return Observable.create { emitter in
+            AF
+                .request(url, method: .post, parameters: parameter, encoder: .json, headers: APIHeader.header.getValue)
+                .responseDecodable(of: BaseResponse<U>.self) { response in
+                    //print(response)
+                    switch response.result {
+                    case .success(let success):
+                        if let result = success.result {
+                            emitter.onNext(result)
+                        }
+                        else {
+                            emitter.onError(NetworkError.invalidResponse)
+                        }
+                    case .failure(let error):
+                        emitter.onError(error)
+                    }
                 }
-            }
-            .resume()
+            return Disposables.create()
+        }
     }
     
     /// 서버에 이미지 post할 때 사용합니다.
@@ -97,76 +94,111 @@ extension APIManager {
     func postImage<U: Decodable>(urlEndpointString: APIEndPoint,
                                             responseDataType: U.Type,
                                             images: [Data],
-                                            completionHandler: @escaping (U)->Void) {
-        guard let url = URL(string: APIEndPoint.baseURL + urlEndpointString.url) else { return }
+                                            completionHandler: @escaping (U)->Void
+    ) -> Observable<U> {
+        guard let url = URL(string: APIEndPoint.baseURL + urlEndpointString.url) else {
+            return Observable.error(NetworkError.invalidURL)
+        }
+        
         print("post image 요청 URL --> \(url)")
         
-        AF.upload(multipartFormData: { MultipartFormData in
-            for image in images {
-                MultipartFormData.append(image, withName: "images", fileName: "\(image).png", mimeType: "image/png")
+        return Observable.create { emitter in
+        
+            AF.upload(multipartFormData: { MultipartFormData in
+                for image in images {
+                    MultipartFormData.append(image, withName: "images", fileName: "\(image).png", mimeType: "image/png")
+                }
+            }, to: url, method: .post, headers: APIHeader.sendImageHeader.getValue)
+            .validate() // 어떤 값을 validate 하는 지 확인 필요
+            .responseDecodable(of: BaseResponse<U>.self) { response in
+//                print(response)
+                switch response.result {
+                case .success(let success):
+                    if let result = success.result {
+                        emitter.onNext(result)
+                    }
+                    else {
+                        emitter.onError(NetworkError.invalidResponse)
+                    }
+                case .failure(let error):
+                    emitter.onError(error)
+                }
             }
-        }, to: url, method: .post, headers: setHeaderToSendImage())
-        .validate()
-        .responseDecodable(of: U.self) { response in
-            print(response)
-            switch response.result {
-            case .success(let success):
-                completionHandler(success)
-            case .failure(let error):
-                print(error.localizedDescription)
-            }
+//            .responseString(completionHandler: { response in
+//                print(response)
+//            }) // 이건 response 디버그용?
+//            .resume()
+            return Disposables.create()
         }
-        .responseString(completionHandler: { response in
-            print(response)
-        })
-        .resume()
     }
     
     func patchData<T: Codable, U: Decodable>(urlEndpointString: APIEndPoint,
                                             responseDataType: U.Type,
                                             requestDataType: T.Type,
-                                            parameter: T?,
-                                            completionHandler: @escaping (U)->Void) {
+                                            parameter: T?
+    ) -> Observable<U> {
         
-        guard let url = URL(string: APIEndPoint.baseURL + urlEndpointString.url) else { return }
+        guard let url = URL(string: APIEndPoint.baseURL + urlEndpointString.url) else {
+            return Observable.error(NetworkError.invalidURL)
+        }
+        
         print("patch 요청 URL --> \(url)")
-        print("Request 쿼리 --> \(parameter)")
+        print("Request 쿼리 --> \(String(describing: parameter))")
         
-        AF
-            .request(url, method: .patch, parameters: parameter, encoder: .json, headers: self.headers)
-            .responseDecodable(of: U.self) { response in
-                //print(response)
-                switch response.result {
-                case .success(let success):
-                    completionHandler(success)
-                case .failure(let error):
-                    print(error.localizedDescription)
+        return Observable.create { emitter in
+            AF
+                .request(url, method: .patch, parameters: parameter, encoder: .json, headers: APIHeader.header.getValue)
+                .responseDecodable(of: BaseResponse<U>.self) { response in
+                    //print(response)
+                    switch response.result {
+                    case .success(let success):
+                        if let result = success.result {
+                            emitter.onNext(result)
+                        }
+                        else {
+                            emitter.onError(NetworkError.invalidResponse)
+                        }
+                    case .failure(let error):
+                        emitter.onError(error)
+                    }
                 }
-            }
-            .resume()
+//                .resume()
+            return Disposables.create()
+        }
     }
     
     func deleteData<T: Codable, U: Decodable>(urlEndpointString: APIEndPoint,
                                             responseDataType: U.Type,
                                             requestDataType: T.Type,
-                                            parameter: T?,
-                                            completionHandler: @escaping (U)->Void) {
+                                            parameter: T?
+    ) -> Observable<U> {
         
-        guard let url = URL(string: APIEndPoint.baseURL + urlEndpointString.url) else { return }
+        guard let url = URL(string: APIEndPoint.baseURL + urlEndpointString.url) else {
+            return Observable.error(NetworkError.invalidURL)
+        }
+        
         print("patch 요청 URL --> \(url)")
-        print("Request 쿼리 --> \(parameter)")
+        print("Request 쿼리 --> \(String(describing: parameter))")
         
-        AF
-            .request(url, method: .delete, parameters: parameter, encoder: .json, headers: self.headers)
-            .responseDecodable(of: U.self) { response in
-                //print(response)
-                switch response.result {
-                case .success(let success):
-                    completionHandler(success)
-                case .failure(let error):
-                    print(error.localizedDescription)
+        return Observable.create { emitter in
+            AF
+                .request(url, method: .delete, parameters: parameter, encoder: .json, headers: APIHeader.sendImageHeader.getValue)
+                .responseDecodable(of: BaseResponse<U>.self) { response in
+                    //print(response)
+                    switch response.result {
+                    case .success(let success):
+                        if let result = success.result {
+                            emitter.onNext(result)
+                        }
+                        else {
+                            emitter.onError(NetworkError.invalidResponse)
+                        }
+                    case .failure(let error):
+                        emitter.onError(error)
+                    }
                 }
-            }
-            .resume()
+//                .resume()
+            return Disposables.create()
+        }
     }
 }

--- a/BookJam/Network/APIManager.swift
+++ b/BookJam/Network/APIManager.swift
@@ -1,0 +1,172 @@
+//
+//  BookJamAPI.swift
+//  BookJam
+//
+//  Created by 박민서 on 11/23/23.
+//
+
+import Foundation
+
+import Alamofire
+import RxSwift
+
+
+class APIManager: ObservableObject  {
+    static let shared = APIManager()
+    private lazy var headers: HTTPHeaders = [    //임시 슈퍼 jwt 토큰
+        "Authorization": "Bearer \(jwtToken)"
+    ]
+    
+    func setHeaderToSendImage() -> HTTPHeaders {
+        headers = [
+            "Authorization": "Bearer \(jwtToken)",
+            "Content-Type" : "multipart/form-data"
+        ]
+        return headers
+    }
+    
+    // 얘네 테스트용이니 다 날려야 함
+    let jwtToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjMzLCJpYXQiOjE2OTIwMDExNDQsImV4cCI6MTc5MjAwNDc0NCwiaXNzIjoiYm9va2phbSJ9.BGN1CGC4Zu8xRVuH_zA-aTK1GYMWvNitR2mAfgG1zWU"
+
+    let kakaoAppID = "e71c9521872b70f64acf3a7139889342"
+}
+
+// MARK: T에는 요청값 데이터의 모델, U에는 응닶값 데이터의 모델 적기
+extension APIManager {
+    func getData<T: Encodable, U: Decodable>(urlEndpointString: APIEndPoint,
+                                           responseDataType: U.Type,
+                                           requestDataType: T.Type,
+                                           parameter: T?
+    ) -> Observable<U>{
+        
+        guard let url = URL(string: APIEndPoint.baseURL + urlEndpointString.url) else {
+            return Observable.error(NetworkError.invalidURL)
+        }
+        print("get 요청 URL --> \(url)")
+        print("Request 쿼리 --> \(String(describing: parameter))")
+        
+        
+        return Observable.create { emitter in
+            AF
+                .request(url, method: .get, parameters: parameter, headers: self.headers)
+//                .validate(statusCode: 200..<300) // validation code를 몰라요
+                .responseDecodable(of: BaseResponse<U>.self) { response in
+                    print(response)
+                    switch response.result {
+                    case .success(let success):
+                        if let result = success.result {
+                            emitter.onNext(result)
+                        }
+                        else {
+                            emitter.onError(NetworkError.invalidResponse)
+                        }
+                    case .failure(let error):
+//                        print(error.localizedDescription)
+                        emitter.onError(error)
+                    }
+                }
+            return Disposables.create()
+        }
+    }
+    
+    func postData<T: Codable, U: Decodable>(urlEndpointString: APIEndPoint,
+                                            responseDataType: U.Type,
+                                            requestDataType: T.Type,
+                                            parameter: T?,
+                                            completionHandler: @escaping (U)->Void) {
+        guard let url = URL(string: APIEndPoint.baseURL + urlEndpointString.url) else { return }
+        print("post 요청 URL --> \(url)")
+        print("Request 쿼리 --> \(parameter)")
+
+        AF
+            .request(url, method: .post, parameters: parameter, encoder: .json, headers: self.headers)
+            .responseDecodable(of: U.self) { response in
+                //print(response)
+                switch response.result {
+                case .success(let success):
+                    completionHandler(success)
+                case .failure(let error):
+                    print(error.localizedDescription)
+                }
+            }
+            .resume()
+    }
+    
+    /// 서버에 이미지 post할 때 사용합니다.
+    /// request 타입은 정의할 필요 없고 들어갈 이미지 배열을 파라미터에 넣어주세요.
+    func postImage<U: Decodable>(urlEndpointString: APIEndPoint,
+                                            responseDataType: U.Type,
+                                            images: [Data],
+                                            completionHandler: @escaping (U)->Void) {
+        guard let url = URL(string: APIEndPoint.baseURL + urlEndpointString.url) else { return }
+        print("post image 요청 URL --> \(url)")
+        
+        AF.upload(multipartFormData: { MultipartFormData in
+            for image in images {
+                MultipartFormData.append(image, withName: "images", fileName: "\(image).png", mimeType: "image/png")
+            }
+        }, to: url, method: .post, headers: setHeaderToSendImage())
+        .validate()
+        .responseDecodable(of: U.self) { response in
+            print(response)
+            switch response.result {
+            case .success(let success):
+                completionHandler(success)
+            case .failure(let error):
+                print(error.localizedDescription)
+            }
+        }
+        .responseString(completionHandler: { response in
+            print(response)
+        })
+        .resume()
+    }
+    
+    func patchData<T: Codable, U: Decodable>(urlEndpointString: APIEndPoint,
+                                            responseDataType: U.Type,
+                                            requestDataType: T.Type,
+                                            parameter: T?,
+                                            completionHandler: @escaping (U)->Void) {
+        
+        guard let url = URL(string: APIEndPoint.baseURL + urlEndpointString.url) else { return }
+        print("patch 요청 URL --> \(url)")
+        print("Request 쿼리 --> \(parameter)")
+        
+        AF
+            .request(url, method: .patch, parameters: parameter, encoder: .json, headers: self.headers)
+            .responseDecodable(of: U.self) { response in
+                //print(response)
+                switch response.result {
+                case .success(let success):
+                    completionHandler(success)
+                case .failure(let error):
+                    print(error.localizedDescription)
+                }
+            }
+            .resume()
+    }
+    
+    func deleteData<T: Codable, U: Decodable>(urlEndpointString: APIEndPoint,
+                                            responseDataType: U.Type,
+                                            requestDataType: T.Type,
+                                            parameter: T?,
+                                            completionHandler: @escaping (U)->Void) {
+        
+        guard let url = URL(string: APIEndPoint.baseURL + urlEndpointString.url) else { return }
+        print("patch 요청 URL --> \(url)")
+        print("Request 쿼리 --> \(parameter)")
+        
+        AF
+            .request(url, method: .delete, parameters: parameter, encoder: .json, headers: self.headers)
+            .responseDecodable(of: U.self) { response in
+                //print(response)
+                switch response.result {
+                case .success(let success):
+                    completionHandler(success)
+                case .failure(let error):
+                    print(error.localizedDescription)
+                }
+            }
+            .resume()
+    }
+}

--- a/BookJam/Network/Entity/BaseResponse.swift
+++ b/BookJam/Network/Entity/BaseResponse.swift
@@ -1,0 +1,15 @@
+//
+//  BaseResponse.swift
+//  BookJam
+//
+//  Created by 박민서 on 11/27/23.
+//
+
+import Foundation
+
+struct BaseResponse<T: Decodable>: Decodable {
+    let success: Bool?
+    let code: Int?
+    let message: String?
+    let result: T?
+}

--- a/BookJam/Network/Entity/BooksList.swift
+++ b/BookJam/Network/Entity/BooksList.swift
@@ -1,0 +1,19 @@
+//
+//  BooksList.swift
+//  Bookjam
+//
+//  Created by YOUJIM on 2023/08/21.
+//
+
+import Foundation
+
+struct BooksListResponseModel: Codable {
+    var title: String?
+    var author: String?
+    var cover: String?
+    var isbn: String?
+}
+
+struct BooksListRequestModel: Codable {
+    
+}

--- a/BookJam/Network/Entity/EmailDuplicate.swift
+++ b/BookJam/Network/Entity/EmailDuplicate.swift
@@ -1,0 +1,16 @@
+//
+//  EmailDuplicate.swift
+//  Bookjam
+//
+//  Created by YOUJIM on 2023/08/09.
+//
+
+import Foundation
+
+struct DuplicateResponseModel: Codable {
+    let isEmailTaken: Bool?
+}
+
+struct DuplictateRequestModel: Codable {
+    let email: String
+}

--- a/BookJam/Network/Entity/Filter.swift
+++ b/BookJam/Network/Entity/Filter.swift
@@ -1,0 +1,13 @@
+//
+//  Filter.swift
+//  BookJam
+//
+//  Created by 박민서 on 11/28/23.
+//
+
+/// 검색 필터 모델입니다.
+enum filters: String {
+    case rating = "rating"
+    case review = "review"
+    case distance = "distance"
+}

--- a/BookJam/Network/Entity/GetPlaces.swift
+++ b/BookJam/Network/Entity/GetPlaces.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct getPlaceRequestModel: Codable {
+struct getPlaceRequestModel: Codable, Hashable {
     let category: Int
     let sortBy: String?
     let lat: Float?
@@ -34,7 +34,7 @@ struct getPlaceRequestModel: Codable {
 /// images: 서점 이미지 Array
 /// address: 주소 model
 /// coords: 좌표 model
-struct GetPlaceResponseModel: Codable {
+struct GetPlaceResponseModel: Codable, Hashable {
     let placeId: Int?
     let name: String?
     let rating: Float?
@@ -49,7 +49,7 @@ struct GetPlaceResponseModel: Codable {
 /// 이미지에 사용하는 모델입니다
 /// id : 이미지 id
 /// url : 이미지 URL
-struct Image: Codable {
+struct Image: Codable, Hashable {
     let id: Int?
     let url: String?
 }
@@ -57,7 +57,7 @@ struct Image: Codable {
 /// 주소에 사용하는 모델입니다
 /// road : 도로명
 /// jibun : 지번
-struct Address: Codable {
+struct Address: Codable, Hashable {
     let road: String
     let jibun: String?
 }
@@ -65,12 +65,12 @@ struct Address: Codable {
 /// 좌표에 사용하는 모델입니다
 /// lat : 위도
 /// lon: 경도
-struct Coordinate: Codable{
+struct Coordinate: Codable, Hashable{
     let lat: String?
     let lon: String?
 }
 
-struct Author: Codable{
+struct Author: Codable, Hashable{
     let userId: Int?
     let username: String?
     let profileImage: String?

--- a/BookJam/Network/Entity/GetPlaces.swift
+++ b/BookJam/Network/Entity/GetPlaces.swift
@@ -1,0 +1,77 @@
+//
+//  getPlaces.swift
+//  Bookjam
+//
+//  Created by 장준모 on 2023/08/14.
+//
+
+import Foundation
+
+struct getPlaceRequestModel: Codable {
+    let category: Int
+    let sortBy: String?
+    let lat: Float?
+    let lon: Float?
+    let last: Int?
+    
+    init(category: Int, sortBy: String? = nil, lat: Float? = nil, lon: Float? = nil, last: Int? = nil) {
+            self.category = category
+            self.sortBy = sortBy
+            self.lat = lat
+            self.lon = lon
+            self.last = last
+        }
+    
+} 
+
+/// 서점 목록을 불러올 때 사용하는 API RESPONSE Model입니다.
+/// placeId : 서점 고유 식별자
+/// name : 서점 이름
+/// rating : 별점 float
+/// review : 리뷰 갯수
+/// category: 0 - 독립서점, 1 - 책 놀이터, 2 - 도서관
+/// open: true - 영업중 false - 영업X
+/// images: 서점 이미지 Array
+/// address: 주소 model
+/// coords: 좌표 model
+struct GetPlaceResponseModel: Codable {
+    let placeId: Int?
+    let name: String?
+    let rating: Float?
+    let reviewCount: Int?
+    let category: Int?
+    let open: Bool?
+    let images: [Image]?
+    let address: Address?
+    let coords: Coordinate?
+}
+
+/// 이미지에 사용하는 모델입니다
+/// id : 이미지 id
+/// url : 이미지 URL
+struct Image: Codable {
+    let id: Int?
+    let url: String?
+}
+
+/// 주소에 사용하는 모델입니다
+/// road : 도로명
+/// jibun : 지번
+struct Address: Codable {
+    let road: String
+    let jibun: String?
+}
+
+/// 좌표에 사용하는 모델입니다
+/// lat : 위도
+/// lon: 경도
+struct Coordinate: Codable{
+    let lat: String?
+    let lon: String?
+}
+
+struct Author: Codable{
+    let userId: Int?
+    let username: String?
+    let profileImage: String?
+}

--- a/BookJam/Network/Entity/KeywordSearch.swift
+++ b/BookJam/Network/Entity/KeywordSearch.swift
@@ -1,0 +1,22 @@
+//
+//  KeywordSearch.swift
+//  Bookjam
+//
+//  Created by 장준모 on 2023/08/15.
+//
+
+import Foundation
+
+struct KeywordSearchRequestModel: Codable {
+    let keyword: String?
+    let sortBy: String?
+    let lat: Float?
+    let lon: Float?
+}
+
+struct KeywordSearchResponseModel: Codable {
+    let placeId: Int?
+    let name: String
+    let category: Int
+    let address: Address?
+}

--- a/BookJam/Network/Entity/LocationCategory.swift
+++ b/BookJam/Network/Entity/LocationCategory.swift
@@ -1,0 +1,23 @@
+//
+//  LocationCategory.swift
+//  BookJam
+//
+//  Created by 박민서 on 11/28/23.
+//
+
+enum LocationCategory: Int {
+    case BookStore = 0
+    case PlayGround = 1
+    case Library = 2
+    
+    var inKorean: String {
+        switch self {
+        case .BookStore:
+            return "독립 서점"
+        case .PlayGround:
+            return "책 놀이터"
+        case .Library:
+            return "도서관"
+        }
+    }
+}

--- a/BookJam/Network/Entity/Login.swift
+++ b/BookJam/Network/Entity/Login.swift
@@ -1,0 +1,17 @@
+//
+//  Login.swift
+//  Bookjam
+//
+//  Created by YOUJIM on 2023/08/13.
+//
+
+import Foundation
+
+struct userLoginRequestModel: Codable {
+    var email: String
+    var password: String
+}
+
+struct userLoginResponseModel: Codable {
+    
+}

--- a/BookJam/Network/Entity/PlaceId.swift
+++ b/BookJam/Network/Entity/PlaceId.swift
@@ -1,0 +1,26 @@
+//
+//  PlaceId.swift
+//  Bookjam
+//
+//  Created by 장준모 on 2023/08/17.
+//
+
+import Foundation
+
+struct PlaceIdRequestModel: Codable {
+    let placeId: Int
+}
+
+struct PlaceIdResponseModel: Codable {
+    let placeId: Int?
+    let name: String?
+    let category: Int?
+    let rating: Float?
+    let reviewCount: Int?
+    let website: String?
+    let address: Address?
+    let images: [Image]?
+    let open : Bool?
+    let bookmarked: Bool?
+}
+

--- a/BookJam/Network/Entity/PlaceIdActivities.swift
+++ b/BookJam/Network/Entity/PlaceIdActivities.swift
@@ -7,13 +7,12 @@
 
 import Foundation
 
-struct PlaceIdActivitiesResponseModel: Codable {
+struct PlaceIdActivitiesResponseModel: Codable, Hashable {
     let error: Bool?
-    
     let result: [Activities]
 }
 
-struct Activities: Codable{
+struct Activities: Codable, Hashable{
     let activityId: Int?
     let createdAt: String?
     let updatedAt: String?

--- a/BookJam/Network/Entity/PlaceIdActivities.swift
+++ b/BookJam/Network/Entity/PlaceIdActivities.swift
@@ -1,0 +1,29 @@
+//
+//  PlaceIdActivity.swift
+//  Bookjam
+//
+//  Created by 장준모 on 2023/08/19.
+//
+
+import Foundation
+
+struct PlaceIdActivitiesResponseModel: Codable {
+    let error: Bool?
+    
+    let result: [Activities]
+}
+
+struct Activities: Codable{
+    let activityId: Int?
+    let createdAt: String?
+    let updatedAt: String?
+    let placeId: Int?
+    let title: String
+    let info: String
+    let capacity: Int?
+    let headcount: Int?
+    let totalRating: Float?
+    let reviewCount: Int?
+    let imageUrl: String?
+//    let like_count: Int?
+}

--- a/BookJam/Network/Entity/PlaceIdBooks.swift
+++ b/BookJam/Network/Entity/PlaceIdBooks.swift
@@ -1,0 +1,17 @@
+//
+//  PlaceIdBooks.swift
+//  Bookjam
+//
+//  Created by 장준모 on 2023/08/19.
+//
+
+import Foundation
+
+struct PlaceIdBooksResponseModel: Codable {
+    let title: String?
+    let author: String?
+    let cover: String?  //이미지
+    let description: String?
+    let isbn: String?
+    let publisher: String?
+}

--- a/BookJam/Network/Entity/PlaceIdBooks.swift
+++ b/BookJam/Network/Entity/PlaceIdBooks.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct PlaceIdBooksResponseModel: Codable {
+struct PlaceIdBooksResponseModel: Codable, Hashable {
     let title: String?
     let author: String?
     let cover: String?  //이미지

--- a/BookJam/Network/Entity/PlaceIdNews.swift
+++ b/BookJam/Network/Entity/PlaceIdNews.swift
@@ -1,0 +1,18 @@
+//
+//  PlaceIdNews.swift
+//  Bookjam
+//
+//  Created by 장준모 on 2023/08/18.
+//
+
+import Foundation
+
+struct PlaceIdNewsResponseModel: Codable {
+    let newsId: Int?
+    let createdAt: String?
+    let updatedAt: String?
+    let title: String?
+    let contents: String?
+    let placeId: Int?
+
+}

--- a/BookJam/Network/Entity/PlaceIdNews.swift
+++ b/BookJam/Network/Entity/PlaceIdNews.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct PlaceIdNewsResponseModel: Codable {
+struct PlaceIdNewsResponseModel: Codable, Hashable {
     let newsId: Int?
     let createdAt: String?
     let updatedAt: String?

--- a/BookJam/Network/Entity/PlaceIdReviews.swift
+++ b/BookJam/Network/Entity/PlaceIdReviews.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct PlaceIdReviewsResponseModel: Codable {
+struct PlaceIdReviewsResponseModel: Codable, Hashable {
     let reviewId: Int?
     let visitedAt: String?
     let contents: String?

--- a/BookJam/Network/Entity/PlaceIdReviews.swift
+++ b/BookJam/Network/Entity/PlaceIdReviews.swift
@@ -1,0 +1,17 @@
+//
+//  PlaceIdReviews.swift
+//  Bookjam
+//
+//  Created by 장준모 on 2023/08/20.
+//
+
+import Foundation
+
+struct PlaceIdReviewsResponseModel: Codable {
+    let reviewId: Int?
+    let visitedAt: String?
+    let contents: String?
+    let rating: Float?
+    let images: [Image]?
+    let author: Author
+}

--- a/BookJam/Network/Entity/RecommendFriend.swift
+++ b/BookJam/Network/Entity/RecommendFriend.swift
@@ -1,0 +1,17 @@
+//
+//  RecommendFriend.swift
+//  Bookjam
+//
+//  Created by YOUJIM on 2023/08/17.
+//
+
+import Foundation
+
+struct RecommendFriendRequestModel: Codable {
+    
+}
+
+struct RecommendFriendResponseModel: Codable {
+    let userId: Int?
+    let name, email, username, profileImage: String?
+}

--- a/BookJam/Network/Entity/Record.swift
+++ b/BookJam/Network/Entity/Record.swift
@@ -1,0 +1,24 @@
+//
+//  Record.swift
+//  Bookjam
+//
+//  Created by YOUJIM on 2023/08/16.
+//
+
+import Foundation
+
+struct RecordResponseModel: Codable {
+    let recorded: Bool?
+    let recordId: Int?
+}
+
+struct RecordRequestModel: Codable {
+    // let place: Int?
+    let isbn: Int?
+    let date: String?
+    let emotions: Int?
+    let activity: Int?
+    let contents: String?
+    let isNotPublic: Int?
+    let commentNotAllowed: Int?
+}

--- a/BookJam/Network/Entity/RecordFriend.swift
+++ b/BookJam/Network/Entity/RecordFriend.swift
@@ -1,0 +1,31 @@
+//
+//  RecordFriend.swift
+//  Bookjam
+//
+//  Created by YOUJIM on 2023/08/22.
+//
+
+import Foundation
+
+
+struct RecordsFriendRequestModel: Codable {
+    
+}
+
+struct RecordsFriendResponseModel: Codable {
+    let record_id, user_id: Int
+    let username: String
+    let profile_image: String
+    let created_at: String
+    let status: Int
+    let date: String
+    let place_id: Int?
+    let name: String?
+    let category: Int
+    let book: String?
+    let activities, emotions: Int
+    let contents: String
+    let comment_not_allowed, comment_count, like_count: Int
+    let images_url: [String]?
+    let liked: Int
+}

--- a/BookJam/Network/Entity/RecordImages.swift
+++ b/BookJam/Network/Entity/RecordImages.swift
@@ -1,0 +1,12 @@
+//
+//  RecordImages.swift
+//  Bookjam
+//
+//  Created by YOUJIM on 2023/08/21.
+//
+
+import Foundation
+
+struct RecordImageResponseModel: Codable {
+    var recorded: Bool?
+}

--- a/BookJam/Network/Entity/ReviewContent.swift
+++ b/BookJam/Network/Entity/ReviewContent.swift
@@ -1,0 +1,18 @@
+//
+//  ReviewContent.swift
+//  Bookjam
+//
+//  Created by YOUJIM on 2023/08/19.
+//
+
+import Foundation
+
+struct ReviewContentRequestModel: Codable {
+    let visitedAt: String?
+    let contents: String?
+    let rating: Float?
+}
+
+struct ReviewContentResponseModel: Codable {
+    let reviewId: Int?
+}

--- a/BookJam/Network/Entity/ReviewImage.swift
+++ b/BookJam/Network/Entity/ReviewImage.swift
@@ -1,0 +1,12 @@
+//
+//  ReviewImage.swift
+//  Bookjam
+//
+//  Created by YOUJIM on 2023/08/20.
+//
+
+import Foundation
+
+struct ReviewImageResponseModel: Codable {
+    var uploaded: Bool?
+}

--- a/BookJam/Network/Entity/SearchFriend.swift
+++ b/BookJam/Network/Entity/SearchFriend.swift
@@ -1,0 +1,16 @@
+//
+//  SearchFriend.swift
+//  Bookjam
+//
+//  Created by YOUJIM on 2023/08/09.
+//
+
+import Foundation
+
+struct SearchFriendRequestModel: Codable {
+    let email: String?
+}
+
+struct SearchFriendResponseModel: Codable {
+    
+}

--- a/BookJam/Network/Entity/SignUp.swift
+++ b/BookJam/Network/Entity/SignUp.swift
@@ -1,0 +1,19 @@
+//
+//  singUp.swift
+//  Bookjam
+//
+//  Created by 장준모 on 2023/08/14.
+//
+
+import Foundation
+
+struct SignUpRequestModel: Codable {
+    let kakao: Int?
+    let email: String?
+    let password: String?
+    let username: String?
+}
+
+struct SignUPResponseModel: Codable {
+    let result: String?
+}

--- a/BookJam/Network/Entity/UsersActivities.swift
+++ b/BookJam/Network/Entity/UsersActivities.swift
@@ -1,0 +1,24 @@
+//
+//  UsersActivities.swift
+//  Bookjam
+//
+//  Created by YOUJIM on 2023/08/21.
+//
+
+import Foundation
+
+struct UsersActivitiesRequestModel: Codable {
+    
+}
+
+struct UsersActivitiesResponseModel: Codable {
+    let userActivities: [UserActivities]
+}
+
+struct UserActivities: Codable {
+    let activity_id: Int?
+    let title: String?
+    let total_rating: Float?
+    let review_count: Int?
+    let image_url: String?
+}

--- a/BookJam/Network/Entity/UsersOutline.swift
+++ b/BookJam/Network/Entity/UsersOutline.swift
@@ -1,0 +1,25 @@
+//
+//  UsersOutline.swift
+//  Bookjam
+//
+//  Created by YOUJIM on 2023/08/21.
+//
+
+import Foundation
+
+struct UsersOutlineResponseModel: Codable {
+    let userOutline: UserOutline?
+}
+
+struct UserOutline: Codable {
+    let userId: Int?
+    let profile: String?
+    let username: String?
+    let review: Int?
+    let reserve: Int?
+    let record: Int?
+}
+
+struct UsersOutlineRequestModel: Codable {
+    
+}

--- a/BookJam/Network/Entity/UsersRecords.swift
+++ b/BookJam/Network/Entity/UsersRecords.swift
@@ -1,0 +1,31 @@
+//
+//  UsersRecords.swift
+//  Bookjam
+//
+//  Created by YOUJIM on 2023/08/21.
+//
+
+import Foundation
+
+struct UsersRecordsResponseModel: Codable {
+    let record_id: Int?
+    let author: Int?
+    let created_at: String?
+    let status: Int?
+    let date: String?
+    let place_id: Int?
+    let name: String?
+    let category: Int?
+    let isbn: String?
+    let activities: Int?
+    let emotions: Int?
+    let contents: String?
+    let comment_not_allowed: Int?
+    let comment_count: Int?
+    let like_count: Int?
+    let images_url: String?
+}
+
+struct UsersRecordsRequestModel: Codable {
+    
+}

--- a/BookJam/Network/Entity/UsersReviews.swift
+++ b/BookJam/Network/Entity/UsersReviews.swift
@@ -1,0 +1,24 @@
+//
+//  UsersReviews.swift
+//  Bookjam
+//
+//  Created by YOUJIM on 2023/08/21.
+//
+
+import Foundation
+
+struct UsersReviewsRequestModel: Codable {
+    
+}
+
+struct UsersReviewsResponseModel: Codable {
+    let userReviews: [UserReviews]
+}
+
+struct UserReviews: Codable {
+    let review_id: Int?
+    let visited_at: String?
+    let name: String?
+    let category: Int?
+    let image_url: String?
+}

--- a/BookJam/Network/NetworkError.swift
+++ b/BookJam/Network/NetworkError.swift
@@ -1,0 +1,16 @@
+//
+//  NetworkError.swift
+//  BookJam
+//
+//  Created by 박민서 on 11/28/23.
+//
+
+import Foundation
+
+enum NetworkError: Error {
+    case invalidURL
+    case invalidDataEncoding
+    case requestFailed(Error)
+    case invalidResponse
+    case responseDataDecodingFailed(Error)
+}

--- a/BookJam/Source/DetailPage/Model/Entity/Activities.swift
+++ b/BookJam/Source/DetailPage/Model/Entity/Activities.swift
@@ -1,29 +1,29 @@
+////
+////  Activities.swift
+////  BookJam
+////
+////  Created by 장준모 on 11/13/23.
+////
 //
-//  Activities.swift
-//  BookJam
+//import Foundation
 //
-//  Created by 장준모 on 11/13/23.
+//struct PlaceIdActivitiesResponseModel: Codable, Hashable {
+//    let error: Bool?
+//    
+//    let result: [Activities]
+//}
 //
-
-import Foundation
-
-struct PlaceIdActivitiesResponseModel: Codable, Hashable {
-    let error: Bool?
-    
-    let result: [Activities]
-}
-
-struct Activities: Codable, Hashable{
-    let activityId: Int?
-    let createdAt: String?
-    let updatedAt: String?
-    let placeId: Int?
-    let title: String
-    let info: String
-    let capacity: Int?
-    let headcount: Int?
-    let totalRating: Float?
-    let reviewCount: Int?
-    let imageUrl: String?
-//    let like_count: Int?
-}
+//struct Activities: Codable, Hashable{
+//    let activityId: Int?
+//    let createdAt: String?
+//    let updatedAt: String?
+//    let placeId: Int?
+//    let title: String
+//    let info: String
+//    let capacity: Int?
+//    let headcount: Int?
+//    let totalRating: Float?
+//    let reviewCount: Int?
+//    let imageUrl: String?
+////    let like_count: Int?
+//}

--- a/BookJam/Source/DetailPage/Model/Entity/Books.swift
+++ b/BookJam/Source/DetailPage/Model/Entity/Books.swift
@@ -1,17 +1,17 @@
+////
+////  Books.swift
+////  BookJam
+////
+////  Created by 장준모 on 11/13/23.
+////
 //
-//  Books.swift
-//  BookJam
+//import Foundation
 //
-//  Created by 장준모 on 11/13/23.
-//
-
-import Foundation
-
-struct PlaceIdBooksResponseModel: Codable, Hashable {
-    let title: String?
-    let author: String?
-    let cover: String?  //이미지
-    let description: String?
-    let isbn: String?
-    let publisher: String?
-}
+//struct PlaceIdBooksResponseModel: Codable, Hashable {
+//    let title: String?
+//    let author: String?
+//    let cover: String?  //이미지
+//    let description: String?
+//    let isbn: String?
+//    let publisher: String?
+//}

--- a/BookJam/Source/DetailPage/Model/Entity/GetPlaces.swift
+++ b/BookJam/Source/DetailPage/Model/Entity/GetPlaces.swift
@@ -1,77 +1,77 @@
+////
+////  GetPlaces.swift
+////  BookJam
+////
+////  Created by 장준모 on 11/13/23.
+////
 //
-//  GetPlaces.swift
-//  BookJam
+//import Foundation
 //
-//  Created by 장준모 on 11/13/23.
+//struct getPlaceRequestModel: Codable, Hashable {
+//    let category: Int
+//    let sortBy: String?
+//    let lat: Float?
+//    let lon: Float?
+//    let last: Int?
+//    
+//    init(category: Int, sortBy: String? = nil, lat: Float? = nil, lon: Float? = nil, last: Int? = nil) {
+//            self.category = category
+//            self.sortBy = sortBy
+//            self.lat = lat
+//            self.lon = lon
+//            self.last = last
+//        }
+//    
+//}
 //
-
-import Foundation
-
-struct getPlaceRequestModel: Codable, Hashable {
-    let category: Int
-    let sortBy: String?
-    let lat: Float?
-    let lon: Float?
-    let last: Int?
-    
-    init(category: Int, sortBy: String? = nil, lat: Float? = nil, lon: Float? = nil, last: Int? = nil) {
-            self.category = category
-            self.sortBy = sortBy
-            self.lat = lat
-            self.lon = lon
-            self.last = last
-        }
-    
-}
-
-/// 서점 목록을 불러올 때 사용하는 API RESPONSE Model입니다.
-/// placeId : 서점 고유 식별자
-/// name : 서점 이름
-/// rating : 별점 float
-/// review : 리뷰 갯수
-/// category: 0 - 독립서점, 1 - 책 놀이터, 2 - 도서관
-/// open: true - 영업중 false - 영업X
-/// images: 서점 이미지 Array
-/// address: 주소 model
-/// coords: 좌표 model
-struct GetPlaceResponseModel: Codable, Hashable {
-    let placeId: Int?
-    let name: String?
-    let rating: Float?
-    let reviewCount: Int?
-    let category: Int?
-    let open: Bool?
-    let images: [Image]?
-    let address: Address?
-    let coords: Coordinate?
-}
-
-/// 이미지에 사용하는 모델입니다
-/// id : 이미지 id
-/// url : 이미지 URL
-struct Image: Codable, Hashable {
-    let id: Int?
-    let url: String?
-}
-
-/// 주소에 사용하는 모델입니다
-/// road : 도로명
-/// jibun : 지번
-struct Address: Codable, Hashable {
-    let road: String
-    let jibun: String?
-}
-
-/// 좌표에 사용하는 모델입니다
-/// lat : 위도
-/// lon: 경도
-struct Coordinate: Codable, Hashable{
-    let lat: String?
-    let lon: String?
-}
-
-struct Author: Codable, Hashable{
-    let userId: Int?
-    let username: String?
-    let profileImage: String?
-}
+///// 서점 목록을 불러올 때 사용하는 API RESPONSE Model입니다.
+///// placeId : 서점 고유 식별자
+///// name : 서점 이름
+///// rating : 별점 float
+///// review : 리뷰 갯수
+///// category: 0 - 독립서점, 1 - 책 놀이터, 2 - 도서관
+///// open: true - 영업중 false - 영업X
+///// images: 서점 이미지 Array
+///// address: 주소 model
+///// coords: 좌표 model
+//struct GetPlaceResponseModel: Codable, Hashable {
+//    let placeId: Int?
+//    let name: String?
+//    let rating: Float?
+//    let reviewCount: Int?
+//    let category: Int?
+//    let open: Bool?
+//    let images: [Image]?
+//    let address: Address?
+//    let coords: Coordinate?
+//}
+//
+///// 이미지에 사용하는 모델입니다
+///// id : 이미지 id
+///// url : 이미지 URL
+//struct Image: Codable, Hashable {
+//    let id: Int?
+//    let url: String?
+//}
+//
+///// 주소에 사용하는 모델입니다
+///// road : 도로명
+///// jibun : 지번
+//struct Address: Codable, Hashable {
+//    let road: String
+//    let jibun: String?
+//}
+//
+///// 좌표에 사용하는 모델입니다
+///// lat : 위도
+///// lon: 경도
+//struct Coordinate: Codable, Hashable{
+//    let lat: String?
+//    let lon: String?
+//}
+//
+//struct Author: Codable, Hashable{
+//    let userId: Int?
+//    let username: String?
+//    let profileImage: String?
+//}

--- a/BookJam/Source/DetailPage/Model/Entity/News.swift
+++ b/BookJam/Source/DetailPage/Model/Entity/News.swift
@@ -1,18 +1,18 @@
+////
+////  News.swift
+////  BookJam
+////
+////  Created by 장준모 on 11/13/23.
+////
 //
-//  News.swift
-//  BookJam
+//import Foundation
 //
-//  Created by 장준모 on 11/13/23.
+//struct PlaceIdNewsResponseModel: Codable, Hashable {
+//    let newsId: Int?
+//    let createdAt: String?
+//    let updatedAt: String?
+//    let title: String?
+//    let contents: String?
+//    let placeId: Int?
 //
-
-import Foundation
-
-struct PlaceIdNewsResponseModel: Codable, Hashable {
-    let newsId: Int?
-    let createdAt: String?
-    let updatedAt: String?
-    let title: String?
-    let contents: String?
-    let placeId: Int?
-
-}
+//}

--- a/BookJam/Source/DetailPage/Model/Entity/Review.swift
+++ b/BookJam/Source/DetailPage/Model/Entity/Review.swift
@@ -1,35 +1,35 @@
+////
+////  Review.swift
+////  BookJam
+////
+////  Created by 장준모 on 11/13/23.
+////
 //
-//  Review.swift
-//  BookJam
+//import Foundation
 //
-//  Created by 장준모 on 11/13/23.
-//
-
-import Foundation
-
-struct PlaceIdReviewsResponseModel: Decodable, Hashable {
-    let reviewId: Int
-    let visitedAt: String
-    let contents: String
-    let rating: Float
-    let images: [Image]
-    let author: Author
-    
-    private enum CodingKeys: String, CodingKey {
-        case reviewId
-        case visitedAt
-        case contents
-        case rating
-        case images
-        case author
-    }
-    
-    init(reviewId: Int, visitedAt: String, contents: String, rating: Float, images: [Image], author: Author) {
-        self.reviewId = reviewId
-        self.visitedAt = visitedAt
-        self.contents = contents
-        self.rating = rating
-        self.images = images
-        self.author = author
-    }
-}
+//struct PlaceIdReviewsResponseModel: Decodable, Hashable {
+//    let reviewId: Int
+//    let visitedAt: String
+//    let contents: String
+//    let rating: Float
+//    let images: [Image]
+//    let author: Author
+//    
+//    private enum CodingKeys: String, CodingKey {
+//        case reviewId
+//        case visitedAt
+//        case contents
+//        case rating
+//        case images
+//        case author
+//    }
+//    
+//    init(reviewId: Int, visitedAt: String, contents: String, rating: Float, images: [Image], author: Author) {
+//        self.reviewId = reviewId
+//        self.visitedAt = visitedAt
+//        self.contents = contents
+//        self.rating = rating
+//        self.images = images
+//        self.author = author
+//    }
+//}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## 📄 개요
기존의 APIManager를 기반으로, Observable로 반환하도록 재구현했습니다.
APIEndpoint를 Enum케이스로 정의하여, 별도의 파일로 구성했습니다.
APIHeader와 NetworkError를 Enum케이스로 정의하고, 각 파일로 별도 구성하였습니다.
API 연결에 필요한 Entity를 추가하고, 이를 임시로 Network/Entity 에 정의했습니다.


## 🔁 변경 사항
### 변경 내용을 적어주세요 (커밋 번호를 적어주세요)
- 왜, 어떻게 변경했는지 상세한 설명을 작성해주세요 (생략 가능)
[Feat: APIEndpoint 설정 + APIManager get 추가](https://github.com/BookJamm/iOS/commit/18b6cbb75d74b1d48a84262039b2ae13cf9a877e)
[[Feat] APIEndPoint 추가, [Chore] DetailPage Model 임시 주석처리](https://github.com/BookJamm/iOS/commit/5d6b7a6a3c284d55c05c8f41f418c95ddc1a07c5)
[[Chore] DetailPage Model - Network Entity 중복 모델 임시 병합](https://github.com/BookJamm/iOS/commit/cd5be9362a9890f3a37801c6e6f9f383706ac00f)
[[Feat] APIManager에서 Header 분리 -> APIEndPoint에 추가 + APIManager Rx 추가 적용](https://github.com/BookJamm/iOS/commit/d12f6e827fc8a48a720cdd66e51a36316c0defb3)
[[Chore] APIEndpoint, APIHeader, NetworkError 분리](https://github.com/BookJamm/iOS/commit/09b2a02540057a56c122413ea4e49d0a4a69b8f8)

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점
- 현재 M / V / VM 구조에 대해서 논의해봐야 할 것 같습니다. Scene 분기점으로 이루어지는 각 MVVM 폴더 구조 할당은 중복 가능성의 문제점과 접근성의 저하 문제가 있어 보입니다!
- 현재 정의된 Model들은 Network - Entity에 모두 정의되어 있는데, 이를 API Connection에 사용되는 Encodable/Decodable Entity와 MVVM에서 사용하는 Model로 구분해야할 것 같습니다.
- 서버 구동 후 테스트 진행하면서 디버깅해야합니다.

