### PR TITLE
[Feat] MyPage - main 탭 UI+Rx 구현

### DIFF
--- a/BookJam.xcodeproj/project.pbxproj
+++ b/BookJam.xcodeproj/project.pbxproj
@@ -100,6 +100,7 @@
 		88B0DBBC2B37450C0047F0A0 /* MainPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B0DBBB2B37450C0047F0A0 /* MainPageViewController.swift */; };
 		88C431582B5A9B1E00A29180 /* BookClubCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88C431572B5A9B1E00A29180 /* BookClubCollectionViewCell.swift */; };
 		88C4315A2B5AA8B800A29180 /* PublicationCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88C431592B5AA8B800A29180 /* PublicationCollectionViewCell.swift */; };
+		88E8C1DC2B7A0DB7005E5F91 /* UserProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88E8C1DB2B7A0DB7005E5F91 /* UserProfile.swift */; };
 		947B70E12B3C343A0056AC57 /* MainDetailHomeSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 947B70E02B3C343A0056AC57 /* MainDetailHomeSection.swift */; };
 		947B70E32B3C34690056AC57 /* MainDetailTableSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 947B70E22B3C34690056AC57 /* MainDetailTableSection.swift */; };
 		949370C22B308B22005E21FE /* MainDetailReviewTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949370C12B308B22005E21FE /* MainDetailReviewTableViewCell.swift */; };
@@ -242,6 +243,7 @@
 		88B0DBBB2B37450C0047F0A0 /* MainPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainPageViewController.swift; sourceTree = "<group>"; };
 		88C431572B5A9B1E00A29180 /* BookClubCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookClubCollectionViewCell.swift; sourceTree = "<group>"; };
 		88C431592B5AA8B800A29180 /* PublicationCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicationCollectionViewCell.swift; sourceTree = "<group>"; };
+		88E8C1DB2B7A0DB7005E5F91 /* UserProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfile.swift; sourceTree = "<group>"; };
 		947B70E02B3C343A0056AC57 /* MainDetailHomeSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainDetailHomeSection.swift; sourceTree = "<group>"; };
 		947B70E22B3C34690056AC57 /* MainDetailTableSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainDetailTableSection.swift; sourceTree = "<group>"; };
 		949370C12B308B22005E21FE /* MainDetailReviewTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainDetailReviewTableViewCell.swift; sourceTree = "<group>"; };
@@ -600,6 +602,7 @@
 			isa = PBXGroup;
 			children = (
 				8870C8682B78FD90001D083B /* MyPageListCellType.swift */,
+				88E8C1DB2B7A0DB7005E5F91 /* UserProfile.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -1068,6 +1071,7 @@
 				DD0919252AFA6B4F001E5501 /* UIViewController+.swift in Sources */,
 				88472A752B15D9220073AE61 /* RecordImagesDTO.swift in Sources */,
 				885EFABA2B31F98E009F6F7E /* LocationDataMapClusterView.swift in Sources */,
+				88E8C1DC2B7A0DB7005E5F91 /* UserProfile.swift in Sources */,
 				8870C8622B78E8F1001D083B /* MyPageHeaderView.swift in Sources */,
 				88472A742B15D9220073AE61 /* UsersActivitiesDTO.swift in Sources */,
 				DD0919262AFA6B4F001E5501 /* UIScrollView+.swift in Sources */,

--- a/BookJam.xcodeproj/project.pbxproj
+++ b/BookJam.xcodeproj/project.pbxproj
@@ -73,6 +73,10 @@
 		885EFAB52B31F928009F6F7E /* ColorToggleButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 885EFAB42B31F928009F6F7E /* ColorToggleButton.swift */; };
 		885EFAB82B31F97D009F6F7E /* LocationAnnotationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 885EFAB72B31F97D009F6F7E /* LocationAnnotationView.swift */; };
 		885EFABA2B31F98E009F6F7E /* LocationDataMapClusterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 885EFAB92B31F98E009F6F7E /* LocationDataMapClusterView.swift */; };
+		8870C85E2B78E86E001D083B /* MyPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8870C85D2B78E86E001D083B /* MyPageViewModel.swift */; };
+		8870C8602B78E88A001D083B /* MyPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8870C85F2B78E88A001D083B /* MyPageViewController.swift */; };
+		8870C8622B78E8F1001D083B /* MyPageHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8870C8612B78E8F1001D083B /* MyPageHeaderView.swift */; };
+		8870C8642B78E909001D083B /* MyPageCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8870C8632B78E909001D083B /* MyPageCollectionViewCell.swift */; };
 		887A91742B4ED4B300FC8D54 /* MainPageDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 887A91732B4ED4B300FC8D54 /* MainPageDataProvider.swift */; };
 		8885EA972B38779B008DE7F8 /* Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8885EA962B38779B008DE7F8 /* Category.swift */; };
 		8885EA992B387D75008DE7F8 /* SearhBarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8885EA982B387D75008DE7F8 /* SearhBarButton.swift */; };
@@ -209,6 +213,10 @@
 		885EFAB42B31F928009F6F7E /* ColorToggleButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorToggleButton.swift; sourceTree = "<group>"; };
 		885EFAB72B31F97D009F6F7E /* LocationAnnotationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationAnnotationView.swift; sourceTree = "<group>"; };
 		885EFAB92B31F98E009F6F7E /* LocationDataMapClusterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationDataMapClusterView.swift; sourceTree = "<group>"; };
+		8870C85D2B78E86E001D083B /* MyPageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageViewModel.swift; sourceTree = "<group>"; };
+		8870C85F2B78E88A001D083B /* MyPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageViewController.swift; sourceTree = "<group>"; };
+		8870C8612B78E8F1001D083B /* MyPageHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageHeaderView.swift; sourceTree = "<group>"; };
+		8870C8632B78E909001D083B /* MyPageCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageCollectionViewCell.swift; sourceTree = "<group>"; };
 		887A91732B4ED4B300FC8D54 /* MainPageDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainPageDataProvider.swift; sourceTree = "<group>"; };
 		8885EA962B38779B008DE7F8 /* Category.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Category.swift; sourceTree = "<group>"; };
 		8885EA982B387D75008DE7F8 /* SearhBarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearhBarButton.swift; sourceTree = "<group>"; };
@@ -568,6 +576,57 @@
 			path = Annotation;
 			sourceTree = "<group>";
 		};
+		8870C8582B78E831001D083B /* MyPage */ = {
+			isa = PBXGroup;
+			children = (
+				8870C8652B78E962001D083B /* Main */,
+			);
+			path = MyPage;
+			sourceTree = "<group>";
+		};
+		8870C8592B78E838001D083B /* Controller */ = {
+			isa = PBXGroup;
+			children = (
+				8870C85F2B78E88A001D083B /* MyPageViewController.swift */,
+			);
+			path = Controller;
+			sourceTree = "<group>";
+		};
+		8870C85A2B78E83E001D083B /* Model */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		8870C85B2B78E842001D083B /* View */ = {
+			isa = PBXGroup;
+			children = (
+				8870C8612B78E8F1001D083B /* MyPageHeaderView.swift */,
+				8870C8632B78E909001D083B /* MyPageCollectionViewCell.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		8870C85C2B78E846001D083B /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				8870C85D2B78E86E001D083B /* MyPageViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		8870C8652B78E962001D083B /* Main */ = {
+			isa = PBXGroup;
+			children = (
+				8870C8592B78E838001D083B /* Controller */,
+				8870C85A2B78E83E001D083B /* Model */,
+				8870C85B2B78E842001D083B /* View */,
+				8870C85C2B78E846001D083B /* ViewModel */,
+			);
+			path = Main;
+			sourceTree = "<group>";
+		};
 		887A91722B4ED48F00FC8D54 /* Dependancy */ = {
 			isa = PBXGroup;
 			children = (
@@ -797,6 +856,7 @@
 		DD0919122AFA5FC2001E5501 /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				8870C8582B78E831001D083B /* MyPage */,
 				88B0DBB62B35586A0047F0A0 /* MainPage */,
 				DD754DF32AFA4D940001FBC4 /* LaunchScreen.storyboard */,
 				885EFA922B30A1B3009F6F7E /* Common */,
@@ -1001,6 +1061,7 @@
 				DD0919252AFA6B4F001E5501 /* UIViewController+.swift in Sources */,
 				88472A752B15D9220073AE61 /* RecordImagesDTO.swift in Sources */,
 				885EFABA2B31F98E009F6F7E /* LocationDataMapClusterView.swift in Sources */,
+				8870C8622B78E8F1001D083B /* MyPageHeaderView.swift in Sources */,
 				88472A742B15D9220073AE61 /* UsersActivitiesDTO.swift in Sources */,
 				DD0919262AFA6B4F001E5501 /* UIScrollView+.swift in Sources */,
 				885EFA9B2B31DCF3009F6F7E /* LocationViewController.swift in Sources */,
@@ -1035,6 +1096,8 @@
 				88472A7A2B15D9220073AE61 /* UsersRecordsDTO.swift in Sources */,
 				88472A772B15D9220073AE61 /* UsersOutlineDTO.swift in Sources */,
 				88472A992B18CA020073AE61 /* ImageDTO.swift in Sources */,
+				8870C8642B78E909001D083B /* MyPageCollectionViewCell.swift in Sources */,
+				8870C85E2B78E86E001D083B /* MyPageViewModel.swift in Sources */,
 				88472A792B15D9220073AE61 /* LoginDTO.swift in Sources */,
 				DD754DE92AFA4D920001FBC4 /* AppDelegate.swift in Sources */,
 				DD0919182AFA6225001E5501 /* ColorData.swift in Sources */,
@@ -1069,6 +1132,7 @@
 				885EFAAE2B31F809009F6F7E /* BookStoreListViewController.swift in Sources */,
 				949370C22B308B22005E21FE /* MainDetailReviewTableViewCell.swift in Sources */,
 				DD0919162AFA621D001E5501 /* FontData.swift in Sources */,
+				8870C8602B78E88A001D083B /* MyPageViewController.swift in Sources */,
 				88472A712B15D9210073AE61 /* RecommendFriendDTO.swift in Sources */,
 				88472A6E2B15D9210073AE61 /* Filter.swift in Sources */,
 				885EFAB52B31F928009F6F7E /* ColorToggleButton.swift in Sources */,

--- a/BookJam.xcodeproj/project.pbxproj
+++ b/BookJam.xcodeproj/project.pbxproj
@@ -101,6 +101,7 @@
 		88C431582B5A9B1E00A29180 /* BookClubCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88C431572B5A9B1E00A29180 /* BookClubCollectionViewCell.swift */; };
 		88C4315A2B5AA8B800A29180 /* PublicationCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88C431592B5AA8B800A29180 /* PublicationCollectionViewCell.swift */; };
 		88E8C1DC2B7A0DB7005E5F91 /* UserProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88E8C1DB2B7A0DB7005E5F91 /* UserProfile.swift */; };
+		88E8C1DE2B7A1108005E5F91 /* AlertWindowType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88E8C1DD2B7A1108005E5F91 /* AlertWindowType.swift */; };
 		947B70E12B3C343A0056AC57 /* MainDetailHomeSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 947B70E02B3C343A0056AC57 /* MainDetailHomeSection.swift */; };
 		947B70E32B3C34690056AC57 /* MainDetailTableSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 947B70E22B3C34690056AC57 /* MainDetailTableSection.swift */; };
 		949370C22B308B22005E21FE /* MainDetailReviewTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949370C12B308B22005E21FE /* MainDetailReviewTableViewCell.swift */; };
@@ -244,6 +245,7 @@
 		88C431572B5A9B1E00A29180 /* BookClubCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookClubCollectionViewCell.swift; sourceTree = "<group>"; };
 		88C431592B5AA8B800A29180 /* PublicationCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicationCollectionViewCell.swift; sourceTree = "<group>"; };
 		88E8C1DB2B7A0DB7005E5F91 /* UserProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfile.swift; sourceTree = "<group>"; };
+		88E8C1DD2B7A1108005E5F91 /* AlertWindowType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertWindowType.swift; sourceTree = "<group>"; };
 		947B70E02B3C343A0056AC57 /* MainDetailHomeSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainDetailHomeSection.swift; sourceTree = "<group>"; };
 		947B70E22B3C34690056AC57 /* MainDetailTableSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainDetailTableSection.swift; sourceTree = "<group>"; };
 		949370C12B308B22005E21FE /* MainDetailReviewTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainDetailReviewTableViewCell.swift; sourceTree = "<group>"; };
@@ -603,6 +605,7 @@
 			children = (
 				8870C8682B78FD90001D083B /* MyPageListCellType.swift */,
 				88E8C1DB2B7A0DB7005E5F91 /* UserProfile.swift */,
+				88E8C1DD2B7A1108005E5F91 /* AlertWindowType.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -1168,6 +1171,7 @@
 				8885EAA52B3C3743008DE7F8 /* MainPageViewModel.swift in Sources */,
 				88472AA82B18E6DD0073AE61 /* Image.swift in Sources */,
 				949751012AFE3C1300DCC096 /* MainDetailTopView.swift in Sources */,
+				88E8C1DE2B7A1108005E5F91 /* AlertWindowType.swift in Sources */,
 				8885EAA32B3C31E4008DE7F8 /* BookStoreCollectionViewCell.swift in Sources */,
 				88472A7F2B15D9220073AE61 /* RecordFriendDTO.swift in Sources */,
 				8829B0562B667C9A005BD999 /* BookClubCategory.swift in Sources */,

--- a/BookJam.xcodeproj/project.pbxproj
+++ b/BookJam.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		8870C8602B78E88A001D083B /* MyPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8870C85F2B78E88A001D083B /* MyPageViewController.swift */; };
 		8870C8622B78E8F1001D083B /* MyPageHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8870C8612B78E8F1001D083B /* MyPageHeaderView.swift */; };
 		8870C8642B78E909001D083B /* MyPageCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8870C8632B78E909001D083B /* MyPageCollectionViewCell.swift */; };
+		8870C8672B78FA08001D083B /* MyPageProfileViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8870C8662B78FA08001D083B /* MyPageProfileViewCell.swift */; };
 		887A91742B4ED4B300FC8D54 /* MainPageDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 887A91732B4ED4B300FC8D54 /* MainPageDataProvider.swift */; };
 		8885EA972B38779B008DE7F8 /* Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8885EA962B38779B008DE7F8 /* Category.swift */; };
 		8885EA992B387D75008DE7F8 /* SearhBarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8885EA982B387D75008DE7F8 /* SearhBarButton.swift */; };
@@ -217,6 +218,7 @@
 		8870C85F2B78E88A001D083B /* MyPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageViewController.swift; sourceTree = "<group>"; };
 		8870C8612B78E8F1001D083B /* MyPageHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageHeaderView.swift; sourceTree = "<group>"; };
 		8870C8632B78E909001D083B /* MyPageCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageCollectionViewCell.swift; sourceTree = "<group>"; };
+		8870C8662B78FA08001D083B /* MyPageProfileViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageProfileViewCell.swift; sourceTree = "<group>"; };
 		887A91732B4ED4B300FC8D54 /* MainPageDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainPageDataProvider.swift; sourceTree = "<group>"; };
 		8885EA962B38779B008DE7F8 /* Category.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Category.swift; sourceTree = "<group>"; };
 		8885EA982B387D75008DE7F8 /* SearhBarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearhBarButton.swift; sourceTree = "<group>"; };
@@ -604,6 +606,7 @@
 			children = (
 				8870C8612B78E8F1001D083B /* MyPageHeaderView.swift */,
 				8870C8632B78E909001D083B /* MyPageCollectionViewCell.swift */,
+				8870C8662B78FA08001D083B /* MyPageProfileViewCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1173,6 +1176,7 @@
 				DD81286E2B2311CA00743DF2 /* UILabel+.swift in Sources */,
 				882517B42B449119009CFA71 /* MainPageTopViewModel.swift in Sources */,
 				88A7EF402B710EA200E47C8B /* SearchPageResultCountViewCell.swift in Sources */,
+				8870C8672B78FA08001D083B /* MyPageProfileViewCell.swift in Sources */,
 				88472A952B18BF600073AE61 /* AddressDTO.swift in Sources */,
 				94A6BF402B20824B00DF2BF8 /* News.swift in Sources */,
 				88C4315A2B5AA8B800A29180 /* PublicationCollectionViewCell.swift in Sources */,

--- a/BookJam.xcodeproj/project.pbxproj
+++ b/BookJam.xcodeproj/project.pbxproj
@@ -102,6 +102,7 @@
 		88C4315A2B5AA8B800A29180 /* PublicationCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88C431592B5AA8B800A29180 /* PublicationCollectionViewCell.swift */; };
 		88E8C1DC2B7A0DB7005E5F91 /* UserProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88E8C1DB2B7A0DB7005E5F91 /* UserProfile.swift */; };
 		88E8C1DE2B7A1108005E5F91 /* AlertWindowType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88E8C1DD2B7A1108005E5F91 /* AlertWindowType.swift */; };
+		88E8C1E22B7A450F005E5F91 /* CustomAlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88E8C1E12B7A450F005E5F91 /* CustomAlertViewController.swift */; };
 		947B70E12B3C343A0056AC57 /* MainDetailHomeSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 947B70E02B3C343A0056AC57 /* MainDetailHomeSection.swift */; };
 		947B70E32B3C34690056AC57 /* MainDetailTableSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 947B70E22B3C34690056AC57 /* MainDetailTableSection.swift */; };
 		949370C22B308B22005E21FE /* MainDetailReviewTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949370C12B308B22005E21FE /* MainDetailReviewTableViewCell.swift */; };
@@ -246,6 +247,7 @@
 		88C431592B5AA8B800A29180 /* PublicationCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicationCollectionViewCell.swift; sourceTree = "<group>"; };
 		88E8C1DB2B7A0DB7005E5F91 /* UserProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfile.swift; sourceTree = "<group>"; };
 		88E8C1DD2B7A1108005E5F91 /* AlertWindowType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertWindowType.swift; sourceTree = "<group>"; };
+		88E8C1E12B7A450F005E5F91 /* CustomAlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomAlertViewController.swift; sourceTree = "<group>"; };
 		947B70E02B3C343A0056AC57 /* MainDetailHomeSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainDetailHomeSection.swift; sourceTree = "<group>"; };
 		947B70E22B3C34690056AC57 /* MainDetailTableSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainDetailTableSection.swift; sourceTree = "<group>"; };
 		949370C12B308B22005E21FE /* MainDetailReviewTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainDetailReviewTableViewCell.swift; sourceTree = "<group>"; };
@@ -530,6 +532,7 @@
 			children = (
 				DD5E406B2B1CD529002D7686 /* BaseViewController.swift */,
 				885EFAAF2B31F8AC009F6F7E /* BaseBottomSheetViewController.swift */,
+				88E8C1E12B7A450F005E5F91 /* CustomAlertViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -1142,6 +1145,7 @@
 				8830924F2B38642A0082729B /* CategoryButton.swift in Sources */,
 				88A7EF442B71330900E47C8B /* SearchPageCollecionHeaderView.swift in Sources */,
 				949750F92AFE303E00DCC096 /* BookListCollectionViewCell.swift in Sources */,
+				88E8C1E22B7A450F005E5F91 /* CustomAlertViewController.swift in Sources */,
 				8829B05A2B667FAE005BD999 /* MainPageClubCategoryViewModel.swift in Sources */,
 				885EFAAE2B31F809009F6F7E /* BookStoreListViewController.swift in Sources */,
 				949370C22B308B22005E21FE /* MainDetailReviewTableViewCell.swift in Sources */,

--- a/BookJam.xcodeproj/project.pbxproj
+++ b/BookJam.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		8870C8622B78E8F1001D083B /* MyPageHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8870C8612B78E8F1001D083B /* MyPageHeaderView.swift */; };
 		8870C8642B78E909001D083B /* MyPageCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8870C8632B78E909001D083B /* MyPageCollectionViewCell.swift */; };
 		8870C8672B78FA08001D083B /* MyPageProfileViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8870C8662B78FA08001D083B /* MyPageProfileViewCell.swift */; };
+		8870C8692B78FD90001D083B /* MyPageListCellType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8870C8682B78FD90001D083B /* MyPageListCellType.swift */; };
 		887A91742B4ED4B300FC8D54 /* MainPageDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 887A91732B4ED4B300FC8D54 /* MainPageDataProvider.swift */; };
 		8885EA972B38779B008DE7F8 /* Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8885EA962B38779B008DE7F8 /* Category.swift */; };
 		8885EA992B387D75008DE7F8 /* SearhBarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8885EA982B387D75008DE7F8 /* SearhBarButton.swift */; };
@@ -219,6 +220,7 @@
 		8870C8612B78E8F1001D083B /* MyPageHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageHeaderView.swift; sourceTree = "<group>"; };
 		8870C8632B78E909001D083B /* MyPageCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageCollectionViewCell.swift; sourceTree = "<group>"; };
 		8870C8662B78FA08001D083B /* MyPageProfileViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageProfileViewCell.swift; sourceTree = "<group>"; };
+		8870C8682B78FD90001D083B /* MyPageListCellType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageListCellType.swift; sourceTree = "<group>"; };
 		887A91732B4ED4B300FC8D54 /* MainPageDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainPageDataProvider.swift; sourceTree = "<group>"; };
 		8885EA962B38779B008DE7F8 /* Category.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Category.swift; sourceTree = "<group>"; };
 		8885EA982B387D75008DE7F8 /* SearhBarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearhBarButton.swift; sourceTree = "<group>"; };
@@ -597,6 +599,7 @@
 		8870C85A2B78E83E001D083B /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				8870C8682B78FD90001D083B /* MyPageListCellType.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -1058,6 +1061,7 @@
 				88472A7D2B15D9220073AE61 /* EmailDuplicateDTO.swift in Sources */,
 				88472A782B15D9220073AE61 /* PlacesDTO.swift in Sources */,
 				88472A8B2B1892300073AE61 /* APIMethod.swift in Sources */,
+				8870C8692B78FD90001D083B /* MyPageListCellType.swift in Sources */,
 				88472A972B18BFD40073AE61 /* Address.swift in Sources */,
 				88472A6B2B15D9210073AE61 /* ReviewImageDTO.swift in Sources */,
 				88472A832B15EFDE0073AE61 /* APIHeader.swift in Sources */,

--- a/BookJam/Resource/Assets.xcassets/Image/defaultProfileImage.imageset/Contents.json
+++ b/BookJam/Resource/Assets.xcassets/Image/defaultProfileImage.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "image.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BookJam/Resource/Assets.xcassets/Image/defaultProfileImage.imageset/image.svg
+++ b/BookJam/Resource/Assets.xcassets/Image/defaultProfileImage.imageset/image.svg
@@ -1,0 +1,10 @@
+<svg width="90" height="90" viewBox="0 0 90 90" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="45" cy="45" r="44.5" fill="#F5F4F3" stroke="#C1C1C1"/>
+<mask id="mask0_2455_17566" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="11" y="16" width="69" height="104">
+<circle cx="45.5625" cy="85.4346" r="34.3125" fill="white"/>
+<circle cx="45.0653" cy="32.2255" r="15.913" fill="white"/>
+</mask>
+<g mask="url(#mask0_2455_17566)">
+<circle cx="45" cy="45.5625" r="44.4375" fill="#C1C1C1"/>
+</g>
+</svg>

--- a/BookJam/Source/Common/Controller/CustomAlertViewController.swift
+++ b/BookJam/Source/Common/Controller/CustomAlertViewController.swift
@@ -67,9 +67,21 @@ class CustomAlertViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        guard let alertType = self.alertType else {
+            print("alertType not configured")
+            cancelButtonTapped()
+            return
+        }
+        
         setUpView()
         setUpLayout()
-        setUpConstraint()
+        if alertType.displayType == .fullSize {
+            setUpConstraintWithButton()
+        }
+        if alertType.displayType == .textOnly {
+            setUpConstraintWithoutButton()
+        }
         setUpBinding()
     }
     
@@ -94,7 +106,7 @@ class CustomAlertViewController: UIViewController {
     }
 
     // MARK: Constraint
-    private func setUpConstraint() {
+    private func setUpConstraintWithButton() {
         
         alertView.snp.makeConstraints {
             $0.center.equalToSuperview()
@@ -123,6 +135,24 @@ class CustomAlertViewController: UIViewController {
         }
 
     }
+    
+    // MARK: Constraint
+    private func setUpConstraintWithoutButton() {
+        
+        alertView.snp.makeConstraints {
+            $0.center.equalToSuperview()
+            $0.width.equalTo(330)
+            $0.height.equalTo(70).priority(.low)
+        }
+        
+        contentLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(20)
+            $0.bottom.equalToSuperview().offset(-20)
+            $0.leading.equalToSuperview().offset(46)
+            $0.trailing.equalToSuperview().offset(-46)
+        }
+    }
+    
     
     // MARK: Binding
     private func setUpBinding() {

--- a/BookJam/Source/Common/Controller/CustomAlertViewController.swift
+++ b/BookJam/Source/Common/Controller/CustomAlertViewController.swift
@@ -1,0 +1,157 @@
+//
+//  AlertViewController.swift
+//  BookJam
+//
+//  Created by 박민서 on 2/12/24.
+//
+
+import UIKit
+import SnapKit
+import Then
+import RxSwift
+
+/// Custom Alert의 Delegate입니다.
+protocol CustomAlertDelegate {
+    var alertWindowType: AlertWindowType { get } // Alert 창 내용
+    func action()   // confirm button event
+    func exit()     // cancel button event
+}
+
+class CustomAlertViewController: UIViewController {
+    
+    var delegate: CustomAlertDelegate?
+    
+    var disposeBag = DisposeBag()
+    
+    /// 중앙 팝업 창
+    private lazy var alertView: UIView = UIView().then {
+        $0.backgroundColor = .white
+        $0.layer.cornerRadius = 12
+//        $0.clipsToBounds = true
+        $0.layer.shadowRadius = 10
+        $0.layer.shadowColor = UIColor.gray08.cgColor
+    }
+    
+    /// 컨텐츠 라벨
+    private lazy var contentLabel: UILabel = UILabel().then {
+        $0.numberOfLines = 2 // 최대 두 줄
+        $0.textAlignment = .center
+    }
+    
+    /// confirm 버튼
+    private lazy var confirmButton: UIButton = UIButton().then {
+        $0.backgroundColor = .gray02
+        $0.layer.cornerRadius = 5
+    }
+    
+    /// cancel 버튼
+    private lazy var cancelButton: UIButton = UIButton().then {
+        $0.backgroundColor = .main01
+        $0.layer.cornerRadius = 5
+    }
+    
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setUpView()
+        setUpLayout()
+        setUpConstraint()
+    }
+    
+
+    // MARK: View
+    private func setUpView() {
+        self.view.backgroundColor = .gray08
+        self.view.layer.opacity = 0.5
+        configureContent()
+    }
+    
+    
+    // MARK: Layout
+    private func setUpLayout() {
+        [
+            contentLabel,
+            confirmButton,
+            cancelButton
+        ].forEach { alertView.addSubview($0) }
+        
+        [
+            alertView
+        ].forEach { view.addSubview($0) }
+    }
+
+    // MARK: Constraint
+    private func setUpConstraint() {
+        
+        alertView.snp.makeConstraints {
+            $0.center.equalToSuperview()
+            $0.width.equalTo(330)
+            $0.height.equalTo(185)
+        }
+        
+        contentLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(30)
+            $0.leading.equalToSuperview().offset(64)
+            $0.trailing.equalToSuperview().offset(-64)
+        }
+        
+        confirmButton.snp.makeConstraints {
+            $0.leading.equalToSuperview().offset(20)
+            $0.bottom.equalToSuperview().offset(-20)
+            $0.width.equalTo(140)
+            $0.height.equalTo(51)
+        }
+        
+        cancelButton.snp.makeConstraints {
+            $0.trailing.equalToSuperview().offset(-20)
+            $0.bottom.equalToSuperview().offset(-20)
+            $0.width.equalTo(140)
+            $0.height.equalTo(51)
+        }
+
+    }
+    
+    // MARK: Binding
+    private func setUpBinding() {
+        self.confirmButton.rx.tap
+            .debounce(.milliseconds(250), scheduler: MainScheduler())
+            .subscribe(onNext: { [weak self] _ in
+                self?.confirmButtonTapped()
+            })
+            .disposed(by: disposeBag)
+        
+        self.cancelButton.rx.tap
+            .debounce(.milliseconds(250), scheduler: MainScheduler())
+            .subscribe(onNext: { [weak self] _ in
+                self?.cancelButtonTapped()
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    // 확인 버튼 이벤트 처리
+    private func confirmButtonTapped() {
+        self.dismiss(animated: true) {
+            self.delegate?.action()
+        }
+    }
+    
+    // 취소 버튼 이벤트 처리
+    private func cancelButtonTapped() {
+        self.dismiss(animated: true) {
+            self.delegate?.exit()
+        }
+    }
+    
+    private func configureContent() {
+        if let alertType = self.delegate?.alertWindowType {
+            self.contentLabel.attributedText = alertType.attributedMainText
+            self.confirmButton.setAttributedTitle(alertType.attributedConfirmButtonText, for: .normal)
+            self.cancelButton.setAttributedTitle(alertType.attributedCancelButtonText, for: .normal)
+        }
+    }
+}
+
+@available(iOS 17.0, *)
+#Preview {
+    CustomAlertViewController()
+}

--- a/BookJam/Source/MyPage/Main/Controller/MyPageViewController.swift
+++ b/BookJam/Source/MyPage/Main/Controller/MyPageViewController.swift
@@ -91,6 +91,7 @@ final class MyPageViewController: UIViewController {
     private func setUpView() {
         self.view.backgroundColor = .white
         self.navigationController?.navigationBar.isHidden = true
+        self.myPageCollectionView.delegate = self
     }
     
     // MARK: Data Binding
@@ -177,35 +178,6 @@ final class MyPageViewController: UIViewController {
 
     }
     
-    private func showAlert(for alertType: AlertWindowType) {
-        let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .alert)
-        
-        // UIAlertAction 생성
-        let okAction = UIAlertAction(title: "확인", style: .default) { _ in
-            print("확인 버튼이 눌렸습니다.")
-        }
-        
-        let cancelAction = UIAlertAction(title: "취소", style: .cancel) { _ in
-            print("취소 버튼이 눌렸습니다.")
-        }
-        
-        // UIAlertAction을 UIAlertController에 추가
-        alertController.addAction(okAction)
-        alertController.addAction(cancelAction)
-        
-        // AlertWindowType에 따라 메시지 설정
-        switch alertType {
-        case .logout(let userEmail):
-            alertController.title = "로그아웃"
-            alertController.message = "\(userEmail)\n계정에서 로그아웃이 됩니다."
-        case .accountTerminate(let userEmail):
-            alertController.title = "회원탈퇴"
-            alertController.message = "\(userEmail)\n북잼에서 탈퇴 됩니다."
-        }
-        
-        // 현재 화면에 UIAlertController를 표시
-        present(alertController, animated: true, completion: nil)
-    }
 }
 
 
@@ -307,6 +279,43 @@ extension MyPageViewController: UICollectionViewDelegate {
             }
             return header
         }
+    }
+    
+    // Cell Tap Event 처리
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        // myPageDataSource의 itemIdentifier를 통해 해당 item으로 코드를 작성
+        if let selectedItem = myPageDataSource?.itemIdentifier(for: indexPath) {
+            switch selectedItem {
+            case .topProfile(let profile):
+                print("Selected topProfile item with profile: \(profile)")
+            case .myBookLife(let type):
+                print("Selected myBookLife item with type: \(type)")
+            case .myInfo(let type):
+                print("Selected myInfo item with type: \(type)")
+            case .manageAccount(let type):
+                print("Selected manageAccount item with type: \(type)")
+                if type == .logout {
+                    showAlert(alertType: .logout(userEmail: "imStruggling@naver.com"))
+                }
+                if type == .accountTermination {
+                    showAlert(alertType: .accountTerminate(userEmail: "neverDoThis@again.com"))
+                }
+            }
+        }
+        // 선택된 셀에 대한 작업 수행
+        print("Selected item at indexPath: \(indexPath)")
+    }
+
+}
+
+extension MyPageViewController: CustomAlertDelegate {
+
+    func action(alertType: AlertWindowType) {
+        print("액션: \(alertType)")
+    }
+    
+    func exit() {
+        print("Exit")
     }
 
 }

--- a/BookJam/Source/MyPage/Main/Controller/MyPageViewController.swift
+++ b/BookJam/Source/MyPage/Main/Controller/MyPageViewController.swift
@@ -281,14 +281,17 @@ extension MyPageViewController: UICollectionViewDelegate {
             
             switch itemIdentifier {
                 
-            case .topProfile:
+            case .topProfile(let profile):
                 guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MyPageProfileViewCell.id, for: indexPath) as? MyPageProfileViewCell else { return UICollectionViewCell() }
-                // cell configure 필요
+                cell.configure(imageURL: profile.image, name: profile.name)
                 return cell
                 
             case .myBookLife(let type), .myInfo(let type), .manageAccount(let type) :
                 guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MyPageCollectionViewCell.id, for: indexPath) as? MyPageCollectionViewCell else { return UICollectionViewCell() }
                 cell.configure(type: type)
+                cell.settingSwitch.rx.isOn
+                    .skip(1) // 셀 등록시 호출 스킵
+                    .bind(to: self.setNotification).disposed(by: self.disposeBag)
                 return cell
             }
         })

--- a/BookJam/Source/MyPage/Main/Controller/MyPageViewController.swift
+++ b/BookJam/Source/MyPage/Main/Controller/MyPageViewController.swift
@@ -107,6 +107,7 @@ final class MyPageViewController: UIViewController {
         snapshot.appendItems(manageAccList, toSection: .manageAccount)
         self.myPageDataSource?.apply(snapshot)
         
+        showAlert(for: .logout(userEmail: "ㅁㄴㅇㄹ"))
     }
     
     // MARK: Configure View
@@ -153,7 +154,36 @@ final class MyPageViewController: UIViewController {
             $0.bottom.equalTo(self.view.safeAreaLayoutGuide)
         }
     }
-
+    
+    func showAlert(for alertType: AlertWindowType) {
+        let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .alert)
+        
+        // UIAlertAction 생성
+        let okAction = UIAlertAction(title: "확인", style: .default) { _ in
+            print("확인 버튼이 눌렸습니다.")
+        }
+        
+        let cancelAction = UIAlertAction(title: "취소", style: .cancel) { _ in
+            print("취소 버튼이 눌렸습니다.")
+        }
+        
+        // UIAlertAction을 UIAlertController에 추가
+        alertController.addAction(okAction)
+        alertController.addAction(cancelAction)
+        
+        // AlertWindowType에 따라 메시지 설정
+        switch alertType {
+        case .logout(let userEmail):
+            alertController.title = "로그아웃"
+            alertController.message = "\(userEmail)\n계정에서 로그아웃이 됩니다."
+        case .accountTerminate(let userEmail):
+            alertController.title = "회원탈퇴"
+            alertController.message = "\(userEmail)\n북잼에서 탈퇴 됩니다."
+        }
+        
+        // 현재 화면에 UIAlertController를 표시
+        present(alertController, animated: true, completion: nil)
+    }
 }
 
 

--- a/BookJam/Source/MyPage/Main/Controller/MyPageViewController.swift
+++ b/BookJam/Source/MyPage/Main/Controller/MyPageViewController.swift
@@ -1,0 +1,8 @@
+//
+//  MyPageViewController.swift
+//  BookJam
+//
+//  Created by 박민서 on 2/11/24.
+//
+
+import Foundation

--- a/BookJam/Source/MyPage/Main/Controller/MyPageViewController.swift
+++ b/BookJam/Source/MyPage/Main/Controller/MyPageViewController.swift
@@ -5,4 +5,259 @@
 //  Created by 박민서 on 2/11/24.
 //
 
-import Foundation
+import UIKit
+import SnapKit
+import Then
+import RxSwift
+
+
+enum MyPageSection: Hashable {
+    case topProfile // 상단 프로필 섹션
+    case myBookLife // 나의 독서생활 섹션
+    case myInfo // 나의 정보 섹션
+    case manageAccount // 계정 관리 섹션
+    
+    // 헤더 타이틀용
+    var sectionTitle: String? {
+        switch self {
+        case .topProfile:
+            return nil
+        case .myBookLife:
+            return "나의 독서생활"
+        case .myInfo:
+            return "나의 정보"
+        case .manageAccount:
+            return "계정 관리"
+        }
+    }
+}
+
+enum MyPageItem: Hashable {
+    case topProfile // 상단 프로필
+    case myBookLife(MyPageListCellType) // 나의 독서생활
+    case myInfo(MyPageListCellType) // 나의 정보
+    case manageAccount(MyPageListCellType) // 계정 관리
+}
+
+final class MyPageViewController: UIViewController {
+    
+    // MARK: Variables
+    
+    /// Rx - DisposeBag
+    private var disposeBag = DisposeBag()
+    
+    /// Rx - ViewModel
+//    private var viewModel = SearchPageViewModel()
+    
+    /// 상단 "마이페이지" 탭 배경 뷰
+    private lazy var topBarView = UIView().then {
+        $0.backgroundColor = .white
+    }
+    
+    /// "마이페이지" 타이틀 라벨
+    private var topBarTitleLabel: UILabel = UILabel().then {
+        $0.text = "마이페이지"
+        $0.font = paragraph01
+        $0.textColor = .black
+    }
+    
+    /// 마이 페이지 컨텐트 목록 보여주는 콜렉션 뷰
+    private lazy var myPageCollectionView: UICollectionView = UICollectionView(frame: .zero, collectionViewLayout: self.createLayout()).then {
+        $0.backgroundColor = .gray01
+        
+        $0.register(MyPageProfileViewCell.self, forCellWithReuseIdentifier: MyPageProfileViewCell.id) // 상단 프로필 셀
+        $0.register(MyPageCollectionViewCell.self, forCellWithReuseIdentifier: MyPageCollectionViewCell.id) // 각 목록 아이템에 해당하는 셀
+        $0.register(MyPageHeaderView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: MyPageHeaderView.id) // 각 목록 섹션 헤더
+    }
+    
+    private var myPageDataSource: UICollectionViewDiffableDataSource<MyPageSection,MyPageItem>?
+    
+    // MARK: LifeCycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setUpView()
+        setUpLayout()
+        setUpConstraint()
+        setDataSource()
+        setUpBinding()
+        
+        let myBookLifeList:[MyPageItem] = [
+            .participatedActivityStatus,
+            .markedActivities
+        ].map { return MyPageItem.myBookLife($0)}
+        
+        let myInfoList:[MyPageItem] = [
+            .changeProfileOrNickname,
+            .changePassword,
+            .changeNotificationSetting
+        ].map { return MyPageItem.myInfo($0)}
+        
+        let manageAccList:[MyPageItem] = [
+            .userInquiry,
+            .logout,
+            .accountTermination
+        ].map { return MyPageItem.manageAccount($0)}
+        
+        var snapshot = NSDiffableDataSourceSnapshot<MyPageSection,MyPageItem>()
+        snapshot.appendSections([.topProfile, .myBookLife, .myInfo, .manageAccount])
+        snapshot.appendItems([.topProfile], toSection: .topProfile)
+        snapshot.appendItems(myBookLifeList, toSection: .myBookLife)
+        snapshot.appendItems(myInfoList, toSection: .myInfo)
+        snapshot.appendItems(manageAccList, toSection: .manageAccount)
+        self.myPageDataSource?.apply(snapshot)
+        
+    }
+    
+    // MARK: Configure View
+    private func setUpView() {
+        self.view.backgroundColor = .white
+        self.navigationController?.navigationBar.isHidden = true
+    }
+    
+    // MARK: Data Binding
+    private func setUpBinding() {
+
+    }
+    
+    // MARK: Layout
+    private func setUpLayout() {
+        
+        topBarView.addSubview(topBarTitleLabel)
+        
+        [
+            topBarView,
+            myPageCollectionView
+        ].forEach { self.view.addSubview($0)}
+    }
+    
+    
+    // MARK: Constraint
+    private func setUpConstraint() {
+        
+        topBarTitleLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(12)
+            $0.left.equalToSuperview().offset(20)
+            $0.right.equalToSuperview().offset(20).priority(.low)
+            $0.bottom.equalToSuperview().offset(-12)
+        }
+        
+        topBarView.snp.makeConstraints {
+            $0.top.equalTo(self.view.safeAreaLayoutGuide)
+            $0.horizontalEdges.equalTo(self.view.safeAreaLayoutGuide)
+        }
+        
+        myPageCollectionView.snp.makeConstraints {
+            $0.top.equalTo(topBarView.snp.bottom).offset(1)
+            $0.horizontalEdges.equalTo(self.view.safeAreaLayoutGuide)
+            $0.bottom.equalTo(self.view.safeAreaLayoutGuide)
+        }
+    }
+
+}
+
+
+// MARK: UICollecitonView Compositional Layout
+extension MyPageViewController {
+    
+    // MARK: Section Layout을 포함한 Compositional Layout return
+    private func createLayout() -> UICollectionViewCompositionalLayout {
+        let config = UICollectionViewCompositionalLayoutConfiguration()
+        config.scrollDirection = .vertical
+        config.interSectionSpacing = 10
+        return UICollectionViewCompositionalLayout(sectionProvider: { [weak self] sectionIndex, _ in
+            
+            let section = self?.myPageDataSource?.sectionIdentifier(for: sectionIndex)
+
+            switch section {
+                
+            case .topProfile:
+                return self?.createTopProfileViewSection()
+            case .myBookLife, .myInfo, .manageAccount:
+                return self?.createContentSection()
+            default : // 다 해당되지 않는 경우 + section 캐스팅 실패
+                return self?.createContentSection()
+            }
+        }, configuration: config)
+    }
+    
+    // MARK: 상단 탭바 아래 topProfile View Section Layout 생성
+    private func createTopProfileViewSection() -> NSCollectionLayoutSection {
+        // item
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(1.0))
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        // group
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(170))
+        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
+        
+        // section
+        let section = NSCollectionLayoutSection(group: group)
+        section.contentInsets.top = 1
+        return section
+    }
+    
+    // MARK: myBookLife, myInfo, manageAccount Section Layout 생성
+    private func createContentSection() -> NSCollectionLayoutSection {
+        // item
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(1.0))
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        // group
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(56))
+//        let group = NSCollectionLayoutGroup(layoutSize: groupSize)
+        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
+        
+        // header
+        let headerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(60))
+        let header = NSCollectionLayoutBoundarySupplementaryItem(layoutSize: headerSize, elementKind: UICollectionView.elementKindSectionHeader, alignment: .topLeading, absoluteOffset: CGPoint(x: 0, y: 0))
+        
+        // section
+        let section = NSCollectionLayoutSection(group: group)
+        section.boundarySupplementaryItems = [header]
+        return section
+    }
+}
+
+// MARK: UICollectionView Diffable DataSource
+extension MyPageViewController: UICollectionViewDelegate {
+    
+    // Diffable DataSource 설정
+    private func setDataSource() {
+        // 셀 설정
+        myPageDataSource = UICollectionViewDiffableDataSource<MyPageSection,MyPageItem>(collectionView: myPageCollectionView, cellProvider: { (collectionView, indexPath, itemIdentifier) in
+            
+            switch itemIdentifier {
+                
+            case .topProfile:
+                guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MyPageProfileViewCell.id, for: indexPath) as? MyPageProfileViewCell else { return UICollectionViewCell() }
+                // cell configure 필요
+                return cell
+                
+            case .myBookLife(let type), .myInfo(let type), .manageAccount(let type) :
+                guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MyPageCollectionViewCell.id, for: indexPath) as? MyPageCollectionViewCell else { return UICollectionViewCell() }
+                print(type)
+                cell.configure(type: type)
+                return cell
+            }
+        })
+        
+        // 헤더 뷰 설정
+        myPageDataSource?.supplementaryViewProvider = { (collectionView, kind, indexPath) -> UICollectionReusableView in
+            guard let header = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: MyPageHeaderView.id, for: indexPath) as? MyPageHeaderView else { return UICollectionReusableView() }
+
+            if let section = self.myPageDataSource?.snapshot().sectionIdentifiers[indexPath.section] {
+                if section != MyPageSection.topProfile {
+                    header.configure(title: section.sectionTitle ?? "")
+                }
+            }
+            return header
+        }
+    }
+
+}
+
+@available(iOS 17.0,*)
+#Preview {
+    MyPageViewController()
+}

--- a/BookJam/Source/MyPage/Main/Model/AlertWindowType.swift
+++ b/BookJam/Source/MyPage/Main/Model/AlertWindowType.swift
@@ -1,0 +1,45 @@
+//
+//  AlertWindowType.swift
+//  BookJam
+//
+//  Created by 박민서 on 2/12/24.
+//
+
+import Foundation
+import UIKit
+
+/// 팝업 alert 창의 타입표시를 위한 enum입니다
+enum AlertWindowType {
+    /// 로그아웃
+    case logout(userEmail: String)
+    /// 회원탈퇴
+    case accountTerminate(userEmail: String)
+}
+
+extension AlertWindowType {
+    /// 폰트와 색 지정이 완료된 내용 텍스트
+    var attributedMainText: NSAttributedString {
+        switch self {
+            
+        case .logout(let userEmail):
+            let text = "\(userEmail)\n계정에서 로그아웃이 됩니다."
+            let attrString = NSMutableAttributedString(string: text)
+            
+            attrString.addAttribute(.foregroundColor, value: UIColor.alert, range: (text as NSString).range(of: "로그아웃"))
+            
+            attrString.addAttribute(.font, value: title05!, range: NSRange(location: 0, length: attrString.length))
+            
+            return attrString
+            
+        case .accountTerminate(let userEmail):
+            let text = "\(userEmail)\n북잼에서 탈퇴 됩니다."
+            let attrString = NSMutableAttributedString(string: text)
+            
+            attrString.addAttribute(.foregroundColor, value: UIColor.alert, range: (text as NSString).range(of: "탈퇴"))
+            
+            attrString.addAttribute(.font, value: title05!, range: NSRange(location: 0, length: attrString.length))
+            
+            return attrString
+        }
+    }
+}

--- a/BookJam/Source/MyPage/Main/Model/AlertWindowType.swift
+++ b/BookJam/Source/MyPage/Main/Model/AlertWindowType.swift
@@ -14,15 +14,48 @@ enum AlertWindowType {
     case logout(userEmail: String)
     /// 회원탈퇴
     case accountTerminate(userEmail: String)
+    /// 회원탈퇴 완료
+    case accountTerminationCompleted
 }
 
+enum AlertWindowDisplaytype {
+    /// 텍스트 라벨 + 버튼 2개
+    case fullSize
+    /// 텍스트라벨
+    case textOnly
+}
+
+
 extension AlertWindowType {
+    
+    /// alert 창 UI 표시 타입
+    var displayType: AlertWindowDisplaytype {
+        switch self {
+        case .logout, .accountTerminate:
+            return .fullSize
+        case .accountTerminationCompleted:
+            return .textOnly
+        }
+    }
+    
+    /// 기본 폰트 설정의 내용 텍스트
+    var mainText: String {
+        switch self {
+        case .logout(let userEmail):
+            return "\(userEmail)\n계정에서 로그아웃이 됩니다."
+        case .accountTerminate(let userEmail):
+            return "\(userEmail)\n북잼에서 탈퇴 됩니다."
+        case .accountTerminationCompleted:
+            return "북잼에서 탈퇴가 완료되었습니다."
+        }
+    }
+    
     /// 폰트와 색 지정이 완료된 내용 텍스트
     var attributedMainText: NSAttributedString {
         switch self {
             
-        case .logout(let userEmail):
-            let text = "\(userEmail)\n계정에서 로그아웃이 됩니다."
+        case .logout:
+            let text = self.mainText
             let attrString = NSMutableAttributedString(string: text)
             
             attrString.addAttribute(.foregroundColor, value: UIColor.alert, range: (text as NSString).range(of: "로그아웃"))
@@ -30,8 +63,8 @@ extension AlertWindowType {
             
             return attrString
             
-        case .accountTerminate(let userEmail):
-            let text = "\(userEmail)\n북잼에서 탈퇴 됩니다."
+        case .accountTerminate, .accountTerminationCompleted:
+            let text = self.mainText
             let attrString = NSMutableAttributedString(string: text)
             
             attrString.addAttribute(.foregroundColor, value: UIColor.alert, range: (text as NSString).range(of: "탈퇴"))
@@ -48,6 +81,8 @@ extension AlertWindowType {
             return "로그아웃"
         case .accountTerminate:
             return "회원탈퇴"
+        case .accountTerminationCompleted:
+            return "" // confirm 버튼 X
         }
     }
     
@@ -64,6 +99,8 @@ extension AlertWindowType {
         switch self {
         case .logout, .accountTerminate :
             return "아니오"
+        case .accountTerminationCompleted:
+            return "" // cancel 버튼 X
         }
     }
     

--- a/BookJam/Source/MyPage/Main/Model/AlertWindowType.swift
+++ b/BookJam/Source/MyPage/Main/Model/AlertWindowType.swift
@@ -26,7 +26,6 @@ extension AlertWindowType {
             let attrString = NSMutableAttributedString(string: text)
             
             attrString.addAttribute(.foregroundColor, value: UIColor.alert, range: (text as NSString).range(of: "로그아웃"))
-            
             attrString.addAttribute(.font, value: title05!, range: NSRange(location: 0, length: attrString.length))
             
             return attrString
@@ -36,10 +35,43 @@ extension AlertWindowType {
             let attrString = NSMutableAttributedString(string: text)
             
             attrString.addAttribute(.foregroundColor, value: UIColor.alert, range: (text as NSString).range(of: "탈퇴"))
-            
             attrString.addAttribute(.font, value: title05!, range: NSRange(location: 0, length: attrString.length))
             
             return attrString
         }
+    }
+    
+    /// 기본 폰트 설정의 confirm 버튼 텍스트
+    var confirmButtonText: String {
+        switch self {
+        case .logout:
+            return "로그아웃"
+        case .accountTerminate:
+            return "회원탈퇴"
+        }
+    }
+    
+    /// 폰트와 색 지정이 완료된 confirm 버튼 텍스트
+    var attributedConfirmButtonText: NSAttributedString {
+        return NSAttributedString(
+            string: self.confirmButtonText,
+            attributes: [.font: paragraph02!, .foregroundColor: UIColor.black]
+        )
+    }
+    
+    /// 기본 폰트 설정의 cancel 버튼 텍스트
+    var cancelButtonText: String {
+        switch self {
+        case .logout, .accountTerminate :
+            return "아니오"
+        }
+    }
+    
+    /// 폰트와 색 지정이 완료된 cancel 버튼 텍스트
+    var attributedCancelButtonText: NSAttributedString {
+        return NSAttributedString(
+            string: self.cancelButtonText,
+            attributes: [.font: paragraph02!, .foregroundColor: UIColor.white]
+        )
     }
 }

--- a/BookJam/Source/MyPage/Main/Model/MyPageListCellType.swift
+++ b/BookJam/Source/MyPage/Main/Model/MyPageListCellType.swift
@@ -30,3 +30,28 @@ enum MyPageListCellType {
     /// 회원탈퇴
     case accountTermination
 }
+
+extension MyPageListCellType {
+    /// 해당 리스트 아이템의 타이틀명
+    var title: String {
+        switch self {
+            
+        case .participatedActivityStatus:
+            return "활동 참여 현황"
+        case .markedActivities:
+            return "찜한 활동"
+        case .changeProfileOrNickname:
+            return "프로필 / 닉네임 변경"
+        case .changePassword:
+            return "비밀번호 변경"
+        case .changeNotificationSetting:
+            return "알림 설정"
+        case .userInquiry:
+            return "회원 문의"
+        case .logout:
+            return "로그아웃"
+        case .accountTermination:
+            return "회원 탈퇴"
+        }
+    }
+}

--- a/BookJam/Source/MyPage/Main/Model/MyPageListCellType.swift
+++ b/BookJam/Source/MyPage/Main/Model/MyPageListCellType.swift
@@ -1,0 +1,32 @@
+//
+//  MyPageListCellType.swift
+//  BookJam
+//
+//  Created by 박민서 on 2/11/24.
+//
+
+/// 마이 페이지의 선택 목록들의 enum입니다.
+enum MyPageListCellType {
+    
+    // --- 나의 독서생활 ---
+    /// 활동 참여 현황
+    case participatedActivityStatus
+    /// 찜한 활동
+    case markedActivities
+    
+    // --- 나의 정보 ---
+    /// 프로필 / 닉네임 변경
+    case changeProfileOrNickname
+    /// 비밀번호 변경
+    case changePassword
+    /// 알림 설정
+    case changeNotificationSetting
+    
+    // --- 계정 관리 ---
+    /// 회원 문의
+    case userInquiry
+    /// 로그아웃
+    case logout
+    /// 회원탈퇴
+    case accountTermination
+}

--- a/BookJam/Source/MyPage/Main/Model/UserProfile.swift
+++ b/BookJam/Source/MyPage/Main/Model/UserProfile.swift
@@ -12,4 +12,6 @@ struct UserProfile {
     let userId: Int
     let image: String?
     let name: String
+    let userEmail: String
+    let notificationSetting: Bool
 }

--- a/BookJam/Source/MyPage/Main/Model/UserProfile.swift
+++ b/BookJam/Source/MyPage/Main/Model/UserProfile.swift
@@ -1,0 +1,15 @@
+//
+//  UserProfile.swift
+//  BookJam
+//
+//  Created by 박민서 on 2/12/24.
+//
+
+/// 유저 프로필 표시용 모델
+/// - Front 구현용 모델입니다
+/// - API 연결 시 수정 필
+struct UserProfile {
+    let userId: Int
+    let image: String?
+    let name: String
+}

--- a/BookJam/Source/MyPage/Main/Model/UserProfile.swift
+++ b/BookJam/Source/MyPage/Main/Model/UserProfile.swift
@@ -8,7 +8,7 @@
 /// 유저 프로필 표시용 모델
 /// - Front 구현용 모델입니다
 /// - API 연결 시 수정 필
-struct UserProfile {
+struct UserProfile: Hashable {
     let userId: Int
     let image: String?
     let name: String

--- a/BookJam/Source/MyPage/Main/View/MyPageCollectionViewCell.swift
+++ b/BookJam/Source/MyPage/Main/View/MyPageCollectionViewCell.swift
@@ -13,13 +13,22 @@ class MyPageCollectionViewCell: UICollectionViewCell {
     
     static let id = "MyPageCollectionViewCell"
     
-    var listCellType: MyPageListCellType?
+    lazy var listCellType: MyPageListCellType? = nil {
+        didSet {
+            self.applyConfigWithCellType(type: listCellType)
+        }
+    }
     
     /// 리스트 타이틀 라벨
     private lazy var titleLabel: UILabel = UILabel().then {
         $0.text = "default"
         $0.font = paragraph03
         $0.textColor = .black
+    }
+    
+    private lazy var settingSwitch: UISwitch = UISwitch().then {
+        $0.onTintColor = .main01 // 추후 확인 필요
+        $0.isHidden = true
     }
     
     override init(frame: CGRect) {
@@ -35,12 +44,12 @@ class MyPageCollectionViewCell: UICollectionViewCell {
     
     private func setUpView() {
         self.backgroundColor = .white
-        applyConfigWithCellType(type: self.listCellType)
     }
     
     private func setUpLayout() {
         [
-            titleLabel
+            titleLabel,
+            settingSwitch
         ].forEach { self.addSubview($0)}
         
     }
@@ -52,6 +61,12 @@ class MyPageCollectionViewCell: UICollectionViewCell {
             $0.bottom.equalToSuperview().offset(-16)
             $0.leading.equalToSuperview().offset(20)
             $0.trailing.equalToSuperview().offset(-20).priority(.low)
+        }
+        
+        settingSwitch.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(12)
+            $0.bottom.equalToSuperview().offset(-12)
+            $0.trailing.equalToSuperview().offset(-20)
         }
     }
     
@@ -67,6 +82,8 @@ class MyPageCollectionViewCell: UICollectionViewCell {
         self.titleLabel.text = type.title
             
         switch type {
+        case .changeNotificationSetting:
+            self.settingSwitch.isHidden = false
         case .logout:
             self.titleLabel.textColor = .red
         case .accountTermination:

--- a/BookJam/Source/MyPage/Main/View/MyPageCollectionViewCell.swift
+++ b/BookJam/Source/MyPage/Main/View/MyPageCollectionViewCell.swift
@@ -1,0 +1,8 @@
+//
+//  MyPageCollectionViewCell.swift
+//  BookJam
+//
+//  Created by 박민서 on 2/11/24.
+//
+
+import Foundation

--- a/BookJam/Source/MyPage/Main/View/MyPageCollectionViewCell.swift
+++ b/BookJam/Source/MyPage/Main/View/MyPageCollectionViewCell.swift
@@ -26,7 +26,7 @@ class MyPageCollectionViewCell: UICollectionViewCell {
         $0.textColor = .black
     }
     
-    private lazy var settingSwitch: UISwitch = UISwitch().then {
+    lazy var settingSwitch: UISwitch = UISwitch().then {
         $0.onTintColor = .main01 // 추후 확인 필요
         $0.isHidden = true
     }

--- a/BookJam/Source/MyPage/Main/View/MyPageCollectionViewCell.swift
+++ b/BookJam/Source/MyPage/Main/View/MyPageCollectionViewCell.swift
@@ -13,17 +13,12 @@ class MyPageCollectionViewCell: UICollectionViewCell {
     
     static let id = "MyPageCollectionViewCell"
     
-    var viewModel: MyPageCollectionViewCellModel?
+    var listCellType: MyPageListCellType?
     
-    /// 프로필 이미지 뷰
-    private lazy var profileImageView: UIImageView = UIImageView().then {
-        $0.image = UIImage.defaultProfile
-    }
-    
-    /// 프로필 텍스트 라벨
-    private lazy var profileTextLabel: UILabel = UILabel().then {
+    /// 리스트 타이틀 라벨
+    private lazy var titleLabel: UILabel = UILabel().then {
         $0.text = "default"
-        $0.font = paragraph02
+        $0.font = paragraph03
         $0.textColor = .black
     }
     
@@ -40,31 +35,45 @@ class MyPageCollectionViewCell: UICollectionViewCell {
     
     private func setUpView() {
         self.backgroundColor = .white
+        applyConfigWithCellType(type: self.listCellType)
     }
     
     private func setUpLayout() {
         [
-            profileImageView,
-            profileTextLabel
+            titleLabel
         ].forEach { self.addSubview($0)}
         
     }
     
     private func setUpConstraint() {
-        profileImageView.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(24)
-            $0.centerX.equalToSuperview()
-        }
         
-        profileTextLabel.snp.makeConstraints {
-            $0.top.equalTo(profileImageView.snp.bottom).offset(8)
-            $0.centerX.equalToSuperview()
-            $0.bottom.equalToSuperview().offset(-24)
+        titleLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(16)
+            $0.bottom.equalToSuperview().offset(-16)
+            $0.leading.equalToSuperview().offset(20)
+            $0.trailing.equalToSuperview().offset(-20).priority(.low)
         }
     }
     
-    private func setUpBinding() {
+    func configure(type: MyPageListCellType) {
+        self.listCellType = type
+    }
+    
+    /// 해당 Cell Type에 따라 타이틀 라벨의 속성을 조정합니다.
+    private func applyConfigWithCellType(type: MyPageListCellType?) {
         
+        guard let type = type else { return }
+        
+        self.titleLabel.text = type.title
+            
+        switch type {
+        case .logout:
+            self.titleLabel.textColor = .red
+        case .accountTermination:
+            self.titleLabel.textColor = .gray05
+        default:
+            break
+        }
     }
 }
 

--- a/BookJam/Source/MyPage/Main/View/MyPageHeaderView.swift
+++ b/BookJam/Source/MyPage/Main/View/MyPageHeaderView.swift
@@ -5,4 +5,57 @@
 //  Created by 박민서 on 2/11/24.
 //
 
-import Foundation
+import UIKit
+import SnapKit
+import Then
+
+final class MyPageHeaderView: UICollectionReusableView {
+    
+    // MARK: Variables
+    static let id = "MyPageHeaderView"
+    
+    /// 타이틀 라벨
+    private lazy var titleLabel: UILabel = UILabel().then {
+        $0.font = paragraph01
+        $0.textColor = .black
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setUpView()
+        setUpLayout()
+        setUpConstraint()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setUpView() {
+        self.backgroundColor = .white
+    }
+    
+    private func setUpLayout() {
+        [
+            titleLabel
+        ].forEach { self.addSubview($0) }
+    }
+    
+    private func setUpConstraint() {
+        titleLabel.snp.makeConstraints {
+            $0.left.equalToSuperview().offset(20)
+            $0.right.equalToSuperview().offset(-20).priority(.low)
+            $0.centerY.equalToSuperview()
+        }
+    }
+    
+    func configure(title:String) {
+        self.titleLabel.text = title
+    }
+    
+}
+
+@available(iOS 17.0, *)
+#Preview {
+    SearchPageCollecionHeaderView()
+}

--- a/BookJam/Source/MyPage/Main/View/MyPageHeaderView.swift
+++ b/BookJam/Source/MyPage/Main/View/MyPageHeaderView.swift
@@ -1,0 +1,8 @@
+//
+//  MyPageHeaderView.swift
+//  BookJam
+//
+//  Created by 박민서 on 2/11/24.
+//
+
+import Foundation

--- a/BookJam/Source/MyPage/Main/View/MyPageProfileViewCell.swift
+++ b/BookJam/Source/MyPage/Main/View/MyPageProfileViewCell.swift
@@ -8,6 +8,7 @@
 import UIKit
 import SnapKit
 import Then
+import Kingfisher
 
 class MyPageProfileViewCell: UICollectionViewCell {
     
@@ -61,8 +62,13 @@ class MyPageProfileViewCell: UICollectionViewCell {
         }
     }
     
-    private func setUpBinding() {
-        
+    /// 임시 테스트용 Configure입니다. -> API 완성후 보완 필요
+    /// 여기에서 URL을 가지고 Request 하는게 맞는지, ViewModel에서 처리후 VC를 통해 UIImage를 주입받아야 하는지는 추후 고려해야 합니다.
+    func configure(imageURL: String?, name: String) {
+        if let imageURL = imageURL, let url = URL(string: imageURL) {
+            profileImageView.kf.setImage(with: url)
+        }
+        profileTextLabel.text = name
     }
 }
 

--- a/BookJam/Source/MyPage/Main/View/MyPageProfileViewCell.swift
+++ b/BookJam/Source/MyPage/Main/View/MyPageProfileViewCell.swift
@@ -13,8 +13,6 @@ class MyPageProfileViewCell: UICollectionViewCell {
     
     static let id = "MyPageProfileViewCell"
     
-//    var viewModel: MyPageProfileViewCellModel?
-    
     /// 프로필 이미지 뷰
     private lazy var profileImageView: UIImageView = UIImageView().then {
         $0.image = UIImage.defaultProfile

--- a/BookJam/Source/MyPage/Main/View/MyPageProfileViewCell.swift
+++ b/BookJam/Source/MyPage/Main/View/MyPageProfileViewCell.swift
@@ -1,5 +1,5 @@
 //
-//  MyPageCollectionViewCell.swift
+//  MyPageProfileViewCell.swift
 //  BookJam
 //
 //  Created by 박민서 on 2/11/24.
@@ -9,11 +9,11 @@ import UIKit
 import SnapKit
 import Then
 
-class MyPageCollectionViewCell: UICollectionViewCell {
+class MyPageProfileViewCell: UICollectionViewCell {
     
-    static let id = "MyPageCollectionViewCell"
+    static let id = "MyPageProfileViewCell"
     
-    var viewModel: MyPageCollectionViewCellModel?
+//    var viewModel: MyPageProfileViewCellModel?
     
     /// 프로필 이미지 뷰
     private lazy var profileImageView: UIImageView = UIImageView().then {
@@ -70,5 +70,6 @@ class MyPageCollectionViewCell: UICollectionViewCell {
 
 @available(iOS 17.0,*)
 #Preview {
-    MyPageCollectionViewCell()
+    MyPageProfileViewCell()
 }
+

--- a/BookJam/Source/MyPage/Main/ViewModel/MyPageViewModel.swift
+++ b/BookJam/Source/MyPage/Main/ViewModel/MyPageViewModel.swift
@@ -1,0 +1,8 @@
+//
+//  MyPageViewModel.swift
+//  BookJam
+//
+//  Created by 박민서 on 2/11/24.
+//
+
+import Foundation

--- a/BookJam/Source/MyPage/Main/ViewModel/MyPageViewModel.swift
+++ b/BookJam/Source/MyPage/Main/ViewModel/MyPageViewModel.swift
@@ -5,4 +5,59 @@
 //  Created by 박민서 on 2/11/24.
 //
 
-import Foundation
+import RxSwift
+import RxRelay
+
+final class MyPageViewModel: ViewModelType {
+    
+    var disposeBag = DisposeBag()
+    
+    // MARK: Input
+    struct Input {
+        /// 알림 설정
+        let setNotificationSetting: Observable<Bool>
+    }
+    
+    // MARK: Output
+    struct Output {
+        /// 프로필
+        let profile: Observable<UserProfile>
+    }
+    
+    // MARK: Status
+    /// 알림 설정 상태
+    private let notificationSetting = BehaviorRelay<Bool>(value: false)
+    
+    // MARK: Transform
+    func transform(input: Input) -> Output {
+        
+        input.setNotificationSetting
+            .bind(onNext: { [weak self] val in
+                self?.postNotificationSetting(val: val)
+                    .bind(onNext: { result in
+                        self?.notificationSetting.accept(result)
+                    })
+                    .disposed(by: self?.disposeBag ?? DisposeBag())
+            })
+            .disposed(by: self.disposeBag)
+        
+        return Output(profile: getMyProfile())
+    }
+    
+    // MARK: API Call
+    private func getMyProfile() -> Observable<UserProfile> {
+        return Observable.just(
+            UserProfile(
+                userId: 0,
+                image: nil,
+                name: "test",
+                userEmail: "asdf@naver.com",
+                notificationSetting: false
+            ))
+    }
+    
+    private func postNotificationSetting(val: Bool) -> Observable<Bool> {
+        // 서버에서 서버알림설정 변경 뒤 response로 변경 값 return 받음
+        return Observable.just(val)
+    }
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## 📄 개요
MyPage의 메인 화면 UI + Rx로직을 구현했습니다.
후의 추가/제거되는 마이페이지 항목 들을 위해 Compositional Layout + DiffableDataSource를 통해 구현했습니다.

화면 상단의 탭바를 제외하고, 하단 전체가 CollectionView로, 각 컴포넌트들이 Cell 형태로 등록된 상태입니다.
프로필을 로드하여 topProfileViewCell에 표시합니다.

해당 PR은 마이페이지 탭 메인 화면 작업 내용이며, 마이페이지 세부 페이지 진행은 #106 이슈에 이어서 작업합니다.

CustomAlertViewController를 추가했습니다.
적용하고자 하는 VC에 Delegate 적용 후 표시하려는 타입에 맞춰 showAlert를 호출하면 표시되는 방식으로 구현했습니다.
추후 적용 케이스에 따라 변경이 필요해보입니다.
>> 전체화면 Tap시 (AlertView제외) dismiss되는 로직이 필요합니다.

## 🔁 변경 사항
### 변경 내용을 적어주세요 (커밋 번호를 적어주세요)
7065f9acaeed3d8eb0bfe7fe4a6e73d19086dacd
17de6f5f11ba96912261cb8444cb62db8edffabf
9f57e1c4fa01eb51915b596e7208599d5dfcf883
a3aa55fe1bfd843a985f759272b8b099833ed89b
0962869ca11d955fc1a18dd12fbdf05abf133781
9dc0d2f313f513edebc4eeaec731a3c86453e6c5
3e90a04eb66bfad0f2e3010f2def4e009c359a36
d6fc5efe18e9e872897024a9cb016a41563e2d39
6d3e55d85739fdc08b38b5786eea556381df85e4
2681be751c4b23f035eed9635531a202e5549157
13a1c63420fc8ce852cf71770a9742d4832654f4
a6566a4ff0aeef4880c202bca1d688212cd41860
9ee758cede7eb06fc0fb6924947b978601032845
99b9374e806050d5e552e15e9f599e6d70b159c8
77e480ebaa686f499c5a271185aa0a73e89d6599

## 📸 스크린샷
![Simulator Screen Recording - iPhone 15 Pro - 2024-02-13 at 00 22 13](https://github.com/BookJamm/iOS/assets/125115284/c10f119b-ead5-445e-bc6e-6b84b9666082)


## 👀 기타 더 이야기해볼 점
추후 API 완성 시 추가작업이 필요하며, 디자인 컨펌이 필요합니다
